### PR TITLE
feat: add intervention execution view

### DIFF
--- a/apps/table-sim/src/app/api/intervention-execution/[conceptId]/route.ts
+++ b/apps/table-sim/src/app/api/intervention-execution/[conceptId]/route.ts
@@ -1,0 +1,88 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { buildAttemptInsights, buildRealPlayConceptSignals, type WeaknessPool } from "@poker-coach/core/browser";
+import { toDiagnosisHistoryEntries, toInterventionHistoryEntries } from "../../../../lib/coaching-memory";
+import { buildConceptCaseMap } from "../../../../lib/concept-case";
+import { buildTableSimInterventionRecommendations } from "../../../../lib/intervention-decision";
+import { buildDiagnosticInsightsFromAttempts, buildPatternAttemptSignals, hydratePersistedStudyAttempts } from "../../../../lib/intervention-support";
+import { buildInterventionExecutionBundle } from "../../../../lib/intervention-execution";
+import { loadLocalStudyData } from "../../../../lib/local-study-data";
+import { buildTableSimPlayerIntelligence } from "../../../../lib/player-intelligence";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ conceptId: string }> }
+) {
+  try {
+    const { conceptId } = await context.params;
+    const conceptKey = decodeURIComponent(conceptId);
+    const {
+      drills,
+      attempts,
+      srs,
+      importedHands,
+      diagnoses,
+      interventions,
+      decisionSnapshots,
+      retentionSchedules,
+      transferSnapshots,
+      inputSnapshots,
+    } = loadLocalStudyData();
+    const activePool = (request.nextUrl.searchParams.get("pool") ?? attempts[0]?.active_pool ?? "baseline") as WeaknessPool;
+    const drillMap = new Map(drills.map((drill) => [drill.drill_id, drill]));
+    const diagnosisHistory = toDiagnosisHistoryEntries(diagnoses);
+    const interventionHistory = toInterventionHistoryEntries(interventions);
+    const hydratedAttempts = hydratePersistedStudyAttempts(attempts, drills);
+    const now = new Date();
+    const realPlaySignals = buildRealPlayConceptSignals(importedHands);
+    const playerIntelligence = buildTableSimPlayerIntelligence({
+      drills,
+      attemptInsights: buildAttemptInsights(attempts, drillMap),
+      srs,
+      activePool,
+      diagnosticInsights: buildDiagnosticInsightsFromAttempts(hydratedAttempts),
+      diagnosisHistory,
+      interventionHistory,
+      realPlaySignals,
+      patternAttempts: buildPatternAttemptSignals(hydratedAttempts),
+      now,
+    });
+    const recommendations = buildTableSimInterventionRecommendations({
+      playerIntelligence,
+      diagnosisHistory,
+      interventionHistory,
+      realPlaySignals,
+      retentionSchedules,
+    });
+    const conceptCase = buildConceptCaseMap({
+      playerIntelligence,
+      diagnosisHistory,
+      interventionHistory,
+      decisionSnapshots,
+      retentionSchedules,
+      transferSnapshots,
+      inputSnapshots,
+      realPlaySignals,
+      recommendations,
+      now,
+    }).get(conceptKey);
+
+    if (!conceptCase) {
+      return NextResponse.json(
+        { error: "Concept not found", conceptKey },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(
+      buildInterventionExecutionBundle(conceptCase, conceptKey)
+    );
+  } catch (error) {
+    console.error("Failed to build intervention execution bundle:", error);
+    return NextResponse.json(
+      { error: "Failed to build intervention execution data" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/table-sim/src/app/app/concepts/[conceptId]/execution/page.tsx
+++ b/apps/table-sim/src/app/app/concepts/[conceptId]/execution/page.tsx
@@ -1,0 +1,11 @@
+import { InterventionExecutionView } from "@/components/concepts/InterventionExecutionView";
+
+export default async function InterventionExecutionPage({
+  params,
+}: {
+  params: Promise<{ conceptId: string }>;
+}) {
+  const { conceptId } = await params;
+
+  return <InterventionExecutionView conceptId={decodeURIComponent(conceptId)} />;
+}

--- a/apps/table-sim/src/components/concepts/ConceptCaseScreen.tsx
+++ b/apps/table-sim/src/components/concepts/ConceptCaseScreen.tsx
@@ -115,6 +115,12 @@ export function ConceptCaseScreen({ state }: { state: ConceptCaseScreenState }) 
               Open Weakness Explorer
             </Link>
             <Link
+              href={`/app/concepts/${encodeURIComponent(history.conceptKey)}/execution`}
+              className="rounded-[18px] border border-blue-400/18 bg-blue-500/10 px-4 py-3 text-sm font-semibold text-blue-100 transition hover:border-blue-300/28 hover:bg-blue-500/16"
+            >
+              Execute Intervention
+            </Link>
+            <Link
               href={`/app/concepts/${encodeURIComponent(history.conceptKey)}/replay`}
               className="rounded-[18px] border border-amber-400/18 bg-amber-500/10 px-4 py-3 text-sm font-semibold text-amber-100 transition hover:border-amber-300/28 hover:bg-amber-500/16"
             >

--- a/apps/table-sim/src/components/concepts/InterventionExecutionScreen.render.test.tsx
+++ b/apps/table-sim/src/components/concepts/InterventionExecutionScreen.render.test.tsx
@@ -1,0 +1,236 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { InterventionExecutionScreen } from "./InterventionExecutionScreen";
+import type { InterventionExecutionBundle } from "@/lib/intervention-execution";
+
+function makeReplayMetadata() {
+  return {
+    recommendation: {
+      inputChanged: false,
+      outputChanged: false,
+      changedEvidenceFields: [],
+      manifestDrift: { matches: true, changedFields: [] },
+      interpretation: "stable" as const,
+    },
+    transfer: {
+      inputChanged: false,
+      outputChanged: false,
+      changedEvidenceFields: [],
+      manifestDrift: { matches: true, changedFields: [] },
+      interpretation: "stable" as const,
+    },
+  };
+}
+
+function makeActiveBundle(): InterventionExecutionBundle {
+  return {
+    conceptKey: "river_bluff_catching",
+    label: "River Bluff Catching",
+    executionStatus: "active",
+    actionSummary: {
+      action: "add_transfer_block",
+      strategy: "transfer_training",
+      intensity: "high",
+      confidence: "high",
+      priority: 84,
+      summary: "Add a transfer block for River Bluff Catching with transfer training.",
+      decisionReason: "The lab-side gain is real, but transfer is the current gap.",
+      requiresNewAssignment: true,
+      requiresStrategyChange: false,
+      transferFocus: true,
+      currentInterventionId: "int-1",
+      currentInterventionStatus: "stabilizing",
+    },
+    evidenceSummary: {
+      reasonCodes: ["real_play_transfer_gap"],
+      evidence: ["Drill gains are not fully transferring to live play."],
+      supportingSignals: [
+        {
+          kind: "real_play",
+          code: "real_play_review_spots",
+          detail: "2 real-play review spots still map here.",
+        },
+        {
+          kind: "pattern",
+          code: "transfer_gap",
+          detail: "Real-play transfer gap pattern is active.",
+        },
+      ],
+      patternTypes: ["real_play_transfer_gap"],
+      whyNotOtherActions: ["The failure mode is transfer, not raw concept ignorance."],
+    },
+    strategyBlueprint: {
+      strategyType: "transfer_training",
+      title: "Transfer Training Plan",
+      objective: "Bridge drill gains into real-play performance for river bluff-catching.",
+      intensity: "high",
+      targetWeaknessProfile: ["transfer_gap"],
+      recommendedAttemptWindow: { sessions: 4, attempts: 12 },
+      recommendedDrillMix: { repair: 0.2, review: 0.3, applied: 0.35, validation: 0.15 },
+      sessionEmphasis: [],
+      reviewEmphasis: [],
+      transferEmphasis: ["imported_hand_review"],
+      stabilizationEmphasis: [],
+      successCriteriaHints: ["Real-play score closes within 10 points of study score."],
+      escalationTriggerHints: ["No improvement in real-play occurrences after 2 sessions."],
+      retentionFollowUpGuidance: ["Schedule retention validation within 7 days of improvement."],
+      coachNotes: ["Focus on applied and review drills that map to live hands."],
+      rationale: "Transfer is the active gap.",
+      modifiers: [],
+    },
+    historyContext: {
+      diagnosisCount: 3,
+      recurrenceCount: 4,
+      recoveryStage: "stabilizing",
+      interventionCount: 2,
+      activeCount: 1,
+      improvedCount: 1,
+      failedCount: 0,
+      latestStatus: "stabilizing",
+      recurringLeak: true,
+    },
+    nextStep: {
+      nextAction: "run_retention_validation",
+      nextActionType: "retention",
+      nextActionPriority: "high",
+      nextActionReason: "River Bluff Catching is due for a retention check.",
+      blockingRisks: ["retention_due"],
+      coachNote: "Focus on the retention check before adding new material.",
+    },
+    replayMetadata: makeReplayMetadata(),
+  };
+}
+
+describe("InterventionExecutionScreen", () => {
+  it("renders active intervention with blueprint and evidence", () => {
+    const html = renderToStaticMarkup(
+      <InterventionExecutionScreen state={{ loading: false, data: makeActiveBundle() }} />
+    );
+
+    expect(html).toContain("River Bluff Catching");
+    expect(html).toContain("Active Intervention");
+    expect(html).toContain("add transfer block");
+    expect(html).toContain("transfer training");
+    expect(html).toContain("The lab-side gain is real, but transfer is the current gap.");
+  });
+
+  it("renders strategy blueprint panel with drill mix and objective", () => {
+    const html = renderToStaticMarkup(
+      <InterventionExecutionScreen state={{ loading: false, data: makeActiveBundle() }} />
+    );
+
+    expect(html).toContain("Blueprint");
+    expect(html).toContain("Transfer Training Plan");
+    expect(html).toContain("Bridge drill gains into real-play performance");
+    expect(html).toContain("Transfer is the active gap.");
+  });
+
+  it("renders success criteria and escalation triggers", () => {
+    const html = renderToStaticMarkup(
+      <InterventionExecutionScreen state={{ loading: false, data: makeActiveBundle() }} />
+    );
+
+    expect(html).toContain("Success Criteria");
+    expect(html).toContain("Real-play score closes within 10 points of study score.");
+    expect(html).toContain("Escalation Triggers");
+    expect(html).toContain("No improvement in real-play occurrences after 2 sessions.");
+  });
+
+  it("renders evidence panel with reason codes and supporting signals", () => {
+    const html = renderToStaticMarkup(
+      <InterventionExecutionScreen state={{ loading: false, data: makeActiveBundle() }} />
+    );
+
+    expect(html).toContain("Why This Intervention");
+    expect(html).toContain("Drill gains are not fully transferring to live play.");
+    expect(html).toContain("real play transfer gap");
+    expect(html).toContain("2 real-play review spots still map here.");
+    expect(html).toContain("The failure mode is transfer, not raw concept ignorance.");
+  });
+
+  it("renders navigation links to concept detail and replay inspector", () => {
+    const html = renderToStaticMarkup(
+      <InterventionExecutionScreen state={{ loading: false, data: makeActiveBundle() }} />
+    );
+
+    expect(html).toContain("/app/concepts/river_bluff_catching");
+    expect(html).toContain("/app/concepts/river_bluff_catching/replay");
+  });
+
+  it("renders recommended (not yet active) intervention state", () => {
+    const data: InterventionExecutionBundle = {
+      ...makeActiveBundle(),
+      executionStatus: "recommended",
+      actionSummary: {
+        ...makeActiveBundle().actionSummary!,
+        currentInterventionId: undefined,
+        currentInterventionStatus: undefined,
+      },
+    };
+    const html = renderToStaticMarkup(
+      <InterventionExecutionScreen state={{ loading: false, data }} />
+    );
+
+    expect(html).toContain("Recommended Intervention");
+    expect(html).toContain("add transfer block");
+  });
+
+  it("renders no-intervention state cleanly", () => {
+    const data: InterventionExecutionBundle = {
+      ...makeActiveBundle(),
+      executionStatus: "no_intervention",
+      recommendation: undefined,
+      actionSummary: undefined,
+      evidenceSummary: undefined,
+      strategyBlueprint: undefined,
+    };
+    const html = renderToStaticMarkup(
+      <InterventionExecutionScreen state={{ loading: false, data }} />
+    );
+
+    expect(html).toContain("No active intervention");
+    expect(html).toContain("No intervention is currently active or recommended");
+  });
+
+  it("renders sparse blueprint gracefully when absent", () => {
+    const data: InterventionExecutionBundle = {
+      ...makeActiveBundle(),
+      strategyBlueprint: undefined,
+    };
+    const html = renderToStaticMarkup(
+      <InterventionExecutionScreen state={{ loading: false, data }} />
+    );
+
+    expect(html).toContain("No strategy blueprint is available yet.");
+    expect(html).toContain("No success criteria available.");
+    expect(html).toContain("No escalation triggers available.");
+  });
+
+  it("renders loading state cleanly", () => {
+    const html = renderToStaticMarkup(
+      <InterventionExecutionScreen state={{ loading: true }} />
+    );
+
+    expect(html).toContain("Loading intervention");
+  });
+
+  it("renders error state cleanly", () => {
+    const html = renderToStaticMarkup(
+      <InterventionExecutionScreen
+        state={{ loading: false, error: "Failed to load intervention execution data" }}
+      />
+    );
+
+    expect(html).toContain("Execution data unavailable");
+    expect(html).toContain("Failed to load intervention execution data");
+  });
+
+  it("renders null data state cleanly", () => {
+    const html = renderToStaticMarkup(
+      <InterventionExecutionScreen state={{ loading: false, data: null }} />
+    );
+
+    expect(html).toContain("No execution data found");
+  });
+});

--- a/apps/table-sim/src/components/concepts/InterventionExecutionScreen.tsx
+++ b/apps/table-sim/src/components/concepts/InterventionExecutionScreen.tsx
@@ -1,0 +1,646 @@
+import React, { type ReactNode } from "react";
+import Link from "next/link";
+import type {
+  InterventionActionSummary,
+  InterventionEvidenceSummary,
+  InterventionExecutionBundle,
+  InterventionHistoryContext,
+} from "@/lib/intervention-execution";
+import type { InterventionStrategyBlueprint } from "@poker-coach/core/browser";
+
+export interface InterventionExecutionScreenState {
+  loading: boolean;
+  error?: string | null;
+  data?: InterventionExecutionBundle | null;
+}
+
+export function InterventionExecutionScreen({
+  state,
+}: {
+  state: InterventionExecutionScreenState;
+}) {
+  if (state.loading) {
+    return (
+      <ExecutionPageFrame>
+        <ExecutionPanel tone="neutral" title="Loading intervention" eyebrow="Execution View">
+          <p className="text-sm leading-6 text-slate-300">
+            Reading the active intervention, strategy blueprint, and coaching evidence for this concept.
+          </p>
+        </ExecutionPanel>
+      </ExecutionPageFrame>
+    );
+  }
+
+  if (state.error) {
+    return (
+      <ExecutionPageFrame>
+        <ExecutionPanel tone="warning" title="Execution data unavailable" eyebrow="Execution View">
+          <p className="text-sm leading-6 text-slate-200">{state.error}</p>
+        </ExecutionPanel>
+      </ExecutionPageFrame>
+    );
+  }
+
+  if (!state.data) {
+    return (
+      <ExecutionPageFrame>
+        <ExecutionPanel tone="neutral" title="No execution data found" eyebrow="Execution View">
+          <p className="text-sm leading-6 text-slate-300">
+            This concept does not have enough stored coaching history to produce an execution view.
+          </p>
+        </ExecutionPanel>
+      </ExecutionPageFrame>
+    );
+  }
+
+  const { actionSummary, evidenceSummary, strategyBlueprint, historyContext, nextStep } =
+    state.data;
+
+  if (state.data.executionStatus === "no_intervention") {
+    return (
+      <ExecutionPageFrame>
+        <div className="space-y-6">
+          <InterventionExecutionHeader data={state.data} />
+          <ExecutionPanel tone="neutral" title="No active intervention" eyebrow="Execution Status">
+            <p className="text-sm leading-6 text-slate-300">
+              No intervention is currently active or recommended for this concept. The coaching engine
+              has not flagged it as requiring immediate action.
+            </p>
+            <p className="mt-3 text-sm leading-6 text-slate-400">
+              Recovery stage: <span className="text-slate-200">{historyContext.recoveryStage.replace(/_/g, " ")}</span>.
+              {" "}Diagnosis count: <span className="text-slate-200">{historyContext.diagnosisCount}</span>.
+            </p>
+            <ExecutionNavFooter conceptKey={state.data.conceptKey} executionStatus={state.data.executionStatus} />
+          </ExecutionPanel>
+        </div>
+      </ExecutionPageFrame>
+    );
+  }
+
+  return (
+    <ExecutionPageFrame>
+      <div className="space-y-6">
+        <InterventionExecutionHeader data={state.data} />
+
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,1.05fr)_minmax(320px,0.95fr)]">
+          <BlueprintExecutionPanel blueprint={strategyBlueprint} />
+          <ExecutionActionPanel actionSummary={actionSummary!} />
+        </div>
+
+        <div className="grid gap-5 xl:grid-cols-2">
+          <SuccessCriteriaPanel blueprint={strategyBlueprint} />
+          <EscalationPanel blueprint={strategyBlueprint} />
+        </div>
+
+        <ExecutionEvidencePanel
+          evidenceSummary={evidenceSummary!}
+          historyContext={historyContext}
+        />
+
+        <ExecutionFooterSection data={state.data} />
+      </div>
+    </ExecutionPageFrame>
+  );
+}
+
+// ─── Header ──────────────────────────────────────────────────────────────────
+
+export function InterventionExecutionHeader({ data }: { data: InterventionExecutionBundle }) {
+  const { actionSummary, executionStatus, label, conceptKey, nextStep } = data;
+
+  const statusLabel =
+    executionStatus === "active"
+      ? "Active Intervention"
+      : executionStatus === "recommended"
+        ? "Recommended Intervention"
+        : "No Intervention";
+
+  return (
+    <section className="rounded-[34px] border border-white/8 bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.14),rgba(15,23,42,0.96)_48%,rgba(2,6,23,0.98)_100%)] px-6 py-6 shadow-[0_30px_100px_rgba(0,0,0,0.38)] sm:px-7 sm:py-7">
+      <div className="space-y-5">
+        <div className="flex flex-wrap gap-2">
+          <ExecChip label="Intervention Execution" />
+          <ExecChip label={statusLabel} subtle={false} />
+          {actionSummary && (
+            <>
+              <ExecChip label={`${actionSummary.intensity} intensity`} subtle />
+              <ExecChip label={`${actionSummary.confidence} confidence`} subtle />
+            </>
+          )}
+        </div>
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">{conceptKey}</p>
+          <h1 className="max-w-4xl text-3xl font-semibold tracking-tight text-white sm:text-[2.7rem]">
+            {label}
+          </h1>
+          {actionSummary ? (
+            <p className="max-w-3xl text-sm leading-7 text-blue-50/88 sm:text-base">
+              {actionSummary.summary}
+            </p>
+          ) : (
+            <p className="max-w-3xl text-sm leading-7 text-slate-300 sm:text-base">
+              No active or recommended intervention for this concept right now.
+            </p>
+          )}
+        </div>
+        {actionSummary && (
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <ExecMetric label="Action" value={actionSummary.action.replace(/_/g, " ")} />
+            <ExecMetric label="Strategy" value={actionSummary.strategy.replace(/_/g, " ")} />
+            <ExecMetric label="Priority" value={String(actionSummary.priority)} />
+            <ExecMetric label="Next move" value={nextStep.nextAction.replace(/_/g, " ")} />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ─── Blueprint Execution Panel ────────────────────────────────────────────────
+
+export function BlueprintExecutionPanel({ blueprint }: { blueprint?: InterventionStrategyBlueprint }) {
+  if (!blueprint) {
+    return (
+      <ExecutionPanel tone="neutral" title="Strategy Blueprint" eyebrow="Blueprint">
+        <p className="text-sm leading-6 text-slate-300">
+          No strategy blueprint is available yet. A blueprint is generated when a clear strategy is
+          assigned for this concept.
+        </p>
+      </ExecutionPanel>
+    );
+  }
+
+  const { recommendedDrillMix: mix, recommendedAttemptWindow: window, sessionEmphasis, reviewEmphasis, transferEmphasis, stabilizationEmphasis } = blueprint;
+  const allEmphasis = [
+    ...sessionEmphasis.map((e) => ({ label: e, kind: "session" })),
+    ...reviewEmphasis.map((e) => ({ label: e, kind: "review" })),
+    ...transferEmphasis.map((e) => ({ label: e, kind: "transfer" })),
+    ...stabilizationEmphasis.map((e) => ({ label: e, kind: "stabilization" })),
+  ];
+
+  return (
+    <ExecutionPanel tone="neutral" title={blueprint.title} eyebrow="Blueprint">
+      <div className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          <ExecChip label={blueprint.strategyType.replace(/_/g, " ")} />
+          <ExecChip label={`${blueprint.intensity} intensity`} subtle />
+          <ExecChip label={`${window.sessions} sessions · ${window.attempts} attempts`} subtle />
+        </div>
+        <ExecInfoBlock title="Objective" detail={blueprint.objective} />
+        <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+            Recommended drill mix
+          </p>
+          <div className="mt-3 grid grid-cols-4 gap-2 text-center">
+            {(
+              [
+                { label: "Repair", value: mix.repair },
+                { label: "Review", value: mix.review },
+                { label: "Applied", value: mix.applied },
+                { label: "Validation", value: mix.validation },
+              ] as const
+            ).map(({ label, value }) => (
+              <div key={label} className="rounded-[16px] border border-white/8 bg-white/5 p-2.5">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  {label}
+                </p>
+                <p className="mt-1.5 text-lg font-semibold text-white">{Math.round(value * 100)}%</p>
+              </div>
+            ))}
+          </div>
+        </div>
+        {allEmphasis.length > 0 && (
+          <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Emphasis
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {allEmphasis.map((item, i) => (
+                <span
+                  key={`${item.kind}:${i}`}
+                  className="rounded-full border border-blue-400/18 bg-blue-500/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-blue-100"
+                >
+                  {item.label.replace(/_/g, " ")}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+        {blueprint.rationale && (
+          <ExecInfoBlock title="Rationale" detail={blueprint.rationale} />
+        )}
+      </div>
+    </ExecutionPanel>
+  );
+}
+
+// ─── Action Panel ─────────────────────────────────────────────────────────────
+
+export function ExecutionActionPanel({ actionSummary }: { actionSummary: InterventionActionSummary }) {
+  return (
+    <ExecutionPanel tone="neutral" title="Execution Details" eyebrow="Active Move">
+      <div className="space-y-4">
+        <div className="grid gap-3">
+          <ActionField label="Recommended action" value={actionSummary.action.replace(/_/g, " ")} />
+          <ActionField label="Strategy" value={actionSummary.strategy.replace(/_/g, " ")} />
+          <ActionField label="Intensity" value={actionSummary.intensity} />
+          <ActionField label="Confidence" value={actionSummary.confidence} />
+          <ActionField label="Priority score" value={String(actionSummary.priority)} />
+        </div>
+        <ExecInfoBlock title="Decision reason" detail={actionSummary.decisionReason} />
+        <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+            Assignment flags
+          </p>
+          <div className="mt-3 space-y-1.5 text-sm text-slate-200">
+            <p>Requires new assignment: <span className={actionSummary.requiresNewAssignment ? "text-amber-200" : "text-slate-400"}>{actionSummary.requiresNewAssignment ? "yes" : "no"}</span></p>
+            <p>Requires strategy change: <span className={actionSummary.requiresStrategyChange ? "text-amber-200" : "text-slate-400"}>{actionSummary.requiresStrategyChange ? "yes" : "no"}</span></p>
+            <p>Transfer focus: <span className={actionSummary.transferFocus ? "text-blue-200" : "text-slate-400"}>{actionSummary.transferFocus ? "yes" : "no"}</span></p>
+          </div>
+        </div>
+        {actionSummary.currentInterventionId && (
+          <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Active intervention
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-200">
+              ID: <span className="font-mono text-slate-300">{actionSummary.currentInterventionId}</span>
+            </p>
+            {actionSummary.currentInterventionStatus && (
+              <p className="mt-1 text-sm text-slate-300">
+                Status: <span className="text-slate-200">{actionSummary.currentInterventionStatus.replace(/_/g, " ")}</span>
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </ExecutionPanel>
+  );
+}
+
+// ─── Success Criteria Panel ───────────────────────────────────────────────────
+
+export function SuccessCriteriaPanel({ blueprint }: { blueprint?: InterventionStrategyBlueprint }) {
+  if (!blueprint) {
+    return (
+      <ExecutionPanel tone="neutral" title="Success Criteria" eyebrow="Exit Conditions">
+        <p className="text-sm leading-6 text-slate-300">
+          No success criteria available. A blueprint is required to define exit conditions for this intervention.
+        </p>
+      </ExecutionPanel>
+    );
+  }
+
+  return (
+    <ExecutionPanel tone="good" title="Success Criteria" eyebrow="Exit Conditions">
+      <div className="space-y-4">
+        {blueprint.successCriteriaHints.length > 0 ? (
+          <div className="rounded-[22px] border border-emerald-500/16 bg-emerald-500/8 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-200">
+              Success signals
+            </p>
+            <ul className="mt-3 space-y-2 text-sm leading-6 text-emerald-50/92">
+              {blueprint.successCriteriaHints.map((hint, i) => (
+                <li key={i}>• {hint}</li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <p className="text-sm leading-6 text-slate-300">
+            No explicit success criteria are attached to this blueprint.
+          </p>
+        )}
+        {blueprint.retentionFollowUpGuidance.length > 0 && (
+          <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Retention follow-up
+            </p>
+            <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-200">
+              {blueprint.retentionFollowUpGuidance.map((hint, i) => (
+                <li key={i}>• {hint}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {blueprint.coachNotes.length > 0 && (
+          <ExecInfoBlock title="Coach note" detail={blueprint.coachNotes[0]!} />
+        )}
+      </div>
+    </ExecutionPanel>
+  );
+}
+
+// ─── Escalation Panel ─────────────────────────────────────────────────────────
+
+export function EscalationPanel({ blueprint }: { blueprint?: InterventionStrategyBlueprint }) {
+  if (!blueprint) {
+    return (
+      <ExecutionPanel tone="neutral" title="Escalation Triggers" eyebrow="Risk Signals">
+        <p className="text-sm leading-6 text-slate-300">
+          No escalation triggers available. A blueprint is required to define when to escalate this intervention.
+        </p>
+      </ExecutionPanel>
+    );
+  }
+
+  return (
+    <ExecutionPanel tone="warning" title="Escalation Triggers" eyebrow="Risk Signals">
+      <div className="space-y-4">
+        {blueprint.escalationTriggerHints.length > 0 ? (
+          <div className="rounded-[22px] border border-amber-500/18 bg-amber-500/8 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-200">
+              Escalate if
+            </p>
+            <ul className="mt-3 space-y-2 text-sm leading-6 text-amber-50/88">
+              {blueprint.escalationTriggerHints.map((hint, i) => (
+                <li key={i}>• {hint}</li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <p className="text-sm leading-6 text-slate-300">
+            No explicit escalation triggers are attached to this blueprint.
+          </p>
+        )}
+        {blueprint.modifiers.length > 0 && (
+          <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Modifiers
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {blueprint.modifiers.map((mod, i) => (
+                <span
+                  key={i}
+                  className="rounded-full border border-white/8 bg-slate-950/70 px-2.5 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-slate-300"
+                >
+                  {mod.replace(/_/g, " ")}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </ExecutionPanel>
+  );
+}
+
+// ─── Evidence Panel ───────────────────────────────────────────────────────────
+
+export function ExecutionEvidencePanel({
+  evidenceSummary,
+  historyContext,
+}: {
+  evidenceSummary: InterventionEvidenceSummary;
+  historyContext: InterventionHistoryContext;
+}) {
+  return (
+    <ExecutionPanel tone="neutral" title="Why This Intervention" eyebrow="Supporting Evidence">
+      <div className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-3">
+          <ExecStat title="Diagnosis count" detail={`${historyContext.diagnosisCount} persisted diagnosis ${historyContext.diagnosisCount === 1 ? "entry" : "entries"}.`} />
+          <ExecStat title="Recurrence" detail={`${historyContext.recurrenceCount} recurrence${historyContext.recurrenceCount === 1 ? "" : "s"} flagged.${historyContext.recurringLeak ? " Classified as recurring leak." : ""}`} />
+          <ExecStat title="Recovery stage" detail={historyContext.recoveryStage.replace(/_/g, " ")} />
+        </div>
+
+        {evidenceSummary.evidence.length > 0 && (
+          <div className="rounded-[22px] border border-blue-500/16 bg-blue-500/8 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-blue-200">
+              Canonical evidence
+            </p>
+            <ul className="mt-3 space-y-2 text-sm leading-6 text-blue-50/92">
+              {evidenceSummary.evidence.map((item, i) => (
+                <li key={i}>• {item}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {evidenceSummary.reasonCodes.length > 0 && (
+          <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Reason codes
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {evidenceSummary.reasonCodes.map((code) => (
+                <span
+                  key={code}
+                  className="rounded-full border border-white/8 bg-slate-950/70 px-2.5 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-slate-300"
+                >
+                  {code.replace(/_/g, " ")}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {evidenceSummary.supportingSignals.length > 0 && (
+          <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Supporting signals
+            </p>
+            <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-200">
+              {evidenceSummary.supportingSignals.map((sig, i) => (
+                <li key={i} className="flex gap-2">
+                  <span className="shrink-0 rounded-full border border-white/8 bg-slate-950/60 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">
+                    {sig.kind}
+                  </span>
+                  <span>{sig.detail}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {evidenceSummary.patternTypes.length > 0 && (
+          <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Pattern types
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {evidenceSummary.patternTypes.map((type) => (
+                <span
+                  key={type}
+                  className="rounded-full border border-blue-400/18 bg-blue-500/10 px-2.5 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-blue-100"
+                >
+                  {type.replace(/_/g, " ")}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {evidenceSummary.whyNotOtherActions.length > 0 && (
+          <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Why not other actions
+            </p>
+            <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">
+              {evidenceSummary.whyNotOtherActions.map((reason, i) => (
+                <li key={i}>• {reason}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </ExecutionPanel>
+  );
+}
+
+// ─── Footer ───────────────────────────────────────────────────────────────────
+
+function ExecutionFooterSection({ data }: { data: InterventionExecutionBundle }) {
+  const { historyContext, nextStep } = data;
+
+  return (
+    <section className="rounded-[30px] border border-white/8 bg-[linear-gradient(180deg,rgba(15,23,42,0.92),rgba(9,14,27,0.86))] p-5 shadow-[0_24px_80px_rgba(0,0,0,0.3)] backdrop-blur-sm">
+      <div className="grid gap-4 lg:grid-cols-3">
+        <ExecMiniMetric
+          label="Diagnosis count"
+          value={String(historyContext.diagnosisCount)}
+          detail={`Recovery stage: ${historyContext.recoveryStage.replace(/_/g, " ")}.`}
+        />
+        <ExecMiniMetric
+          label="Interventions"
+          value={`${historyContext.interventionCount} total`}
+          detail={`${historyContext.activeCount} active, ${historyContext.improvedCount} improved, ${historyContext.failedCount} failed.`}
+        />
+        <ExecMiniMetric
+          label="Next move"
+          value={nextStep.nextAction.replace(/_/g, " ")}
+          detail={nextStep.nextActionReason}
+        />
+      </div>
+      <ExecutionNavFooter conceptKey={data.conceptKey} executionStatus={data.executionStatus} />
+    </section>
+  );
+}
+
+function ExecutionNavFooter({
+  conceptKey,
+  executionStatus,
+}: {
+  conceptKey: string;
+  executionStatus: string;
+}) {
+  return (
+    <div className="mt-5 flex flex-wrap gap-3">
+      <Link
+        href={`/app/concepts/${encodeURIComponent(conceptKey)}`}
+        className="rounded-[18px] border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:border-white/16 hover:bg-white/10"
+      >
+        Concept Detail
+      </Link>
+      <Link
+        href={`/app/concepts/${encodeURIComponent(conceptKey)}/replay`}
+        className="rounded-[18px] border border-amber-400/18 bg-amber-500/10 px-4 py-3 text-sm font-semibold text-amber-100 transition hover:border-amber-300/28 hover:bg-amber-500/16"
+      >
+        Replay Inspector
+      </Link>
+      <Link
+        href="/app/session"
+        className="rounded-[18px] border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:border-white/16 hover:bg-white/10"
+      >
+        Command Center
+      </Link>
+    </div>
+  );
+}
+
+// ─── Primitives ───────────────────────────────────────────────────────────────
+
+function ExecutionPageFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.10),rgba(3,7,18,0.98)_30%),linear-gradient(180deg,#020617_0%,#07111f_58%,#040816_100%)] px-4 py-6 sm:px-5 sm:py-8">
+      <div className="mx-auto max-w-7xl">{children}</div>
+    </div>
+  );
+}
+
+function ExecutionPanel({
+  eyebrow,
+  title,
+  tone,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  tone: "good" | "warning" | "neutral";
+  children: ReactNode;
+}) {
+  const toneClass =
+    tone === "good"
+      ? "border-emerald-500/14 bg-[linear-gradient(180deg,rgba(7,18,24,0.94),rgba(8,16,28,0.9))]"
+      : tone === "warning"
+        ? "border-amber-500/14 bg-[linear-gradient(180deg,rgba(24,17,7,0.92),rgba(20,14,8,0.88))]"
+        : "border-white/8 bg-[linear-gradient(180deg,rgba(15,23,42,0.92),rgba(9,14,27,0.86))]";
+
+  return (
+    <section
+      className={`rounded-[30px] border p-5 shadow-[0_24px_80px_rgba(0,0,0,0.3)] backdrop-blur-sm ${toneClass}`}
+    >
+      <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-slate-500">{eyebrow}</p>
+      <p className="mt-2 text-2xl font-semibold tracking-tight text-white">{title}</p>
+      <div className="mt-4">{children}</div>
+    </section>
+  );
+}
+
+function ExecInfoBlock({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">{title}</p>
+      <p className="mt-2 text-sm leading-6 text-slate-200">{detail}</p>
+    </div>
+  );
+}
+
+function ExecStat({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">{title}</p>
+      <p className="mt-2 text-sm leading-6 text-slate-200">{detail}</p>
+    </div>
+  );
+}
+
+function ActionField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[16px] border border-white/8 bg-black/20 px-4 py-3">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">{label}</p>
+      <p className="mt-1.5 text-sm font-semibold text-slate-200">{value}</p>
+    </div>
+  );
+}
+
+function ExecMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[24px] border border-white/10 bg-black/20 px-4 py-3.5">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">{label}</p>
+      <p className="mt-2 text-base font-semibold text-white">{value}</p>
+    </div>
+  );
+}
+
+function ExecMiniMetric({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="rounded-[24px] border border-white/8 bg-black/20 p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">{label}</p>
+      <p className="mt-3 text-xl font-semibold tracking-tight text-white">{value}</p>
+      <p className="mt-2 text-sm leading-6 text-slate-300">{detail}</p>
+    </div>
+  );
+}
+
+function ExecChip({ label, subtle = false }: { label: string; subtle?: boolean }) {
+  return (
+    <span
+      className={`rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] ${
+        subtle
+          ? "border-white/8 bg-white/5 text-slate-300"
+          : "border-blue-400/25 bg-blue-500/10 text-blue-100"
+      }`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/table-sim/src/components/concepts/InterventionExecutionView.tsx
+++ b/apps/table-sim/src/components/concepts/InterventionExecutionView.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  InterventionExecutionScreen,
+  type InterventionExecutionScreenState,
+} from "@/components/concepts/InterventionExecutionScreen";
+import type { InterventionExecutionBundle } from "@/lib/intervention-execution";
+
+export function InterventionExecutionView({ conceptId }: { conceptId: string }) {
+  const [state, setState] = useState<InterventionExecutionScreenState>({ loading: true });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadExecution() {
+      setState({ loading: true });
+      try {
+        const response = await fetch(
+          `/api/intervention-execution/${encodeURIComponent(conceptId)}`,
+          { cache: "no-store" }
+        );
+        if (response.status === 404) {
+          if (!cancelled) setState({ loading: false, data: null });
+          return;
+        }
+        if (!response.ok) {
+          throw new Error("Failed to load intervention execution data");
+        }
+        const data = (await response.json()) as InterventionExecutionBundle;
+        if (!cancelled) setState({ loading: false, data });
+      } catch (error) {
+        console.error("Failed to load intervention execution:", error);
+        if (!cancelled) {
+          setState({
+            loading: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to load intervention execution data",
+          });
+        }
+      }
+    }
+
+    loadExecution();
+    return () => {
+      cancelled = true;
+    };
+  }, [conceptId]);
+
+  return <InterventionExecutionScreen state={state} />;
+}

--- a/apps/table-sim/src/lib/intervention-execution.ts
+++ b/apps/table-sim/src/lib/intervention-execution.ts
@@ -1,0 +1,124 @@
+import type {
+  ConceptCaseNextStep,
+  InterventionRecommendation,
+  InterventionSupportingSignal,
+} from "@poker-coach/core/browser";
+import type { InterventionStrategyBlueprint } from "@poker-coach/core/browser";
+import type { ConceptCaseBundle } from "./concept-case";
+import type { EngineReplaySummary } from "./input-snapshots";
+
+export type InterventionExecutionStatus = "no_intervention" | "recommended" | "active";
+
+export interface InterventionActionSummary {
+  action: string;
+  strategy: string;
+  intensity: string;
+  confidence: string;
+  priority: number;
+  summary: string;
+  decisionReason: string;
+  requiresNewAssignment: boolean;
+  requiresStrategyChange: boolean;
+  transferFocus: boolean;
+  currentInterventionId?: string;
+  currentInterventionStatus?: string;
+}
+
+export interface InterventionEvidenceSummary {
+  reasonCodes: string[];
+  evidence: string[];
+  supportingSignals: InterventionSupportingSignal[];
+  patternTypes: string[];
+  whyNotOtherActions: string[];
+}
+
+export interface InterventionHistoryContext {
+  diagnosisCount: number;
+  recurrenceCount: number;
+  recoveryStage: string;
+  interventionCount: number;
+  activeCount: number;
+  improvedCount: number;
+  failedCount: number;
+  latestStatus?: string;
+  recurringLeak: boolean;
+}
+
+export interface InterventionExecutionBundle {
+  conceptKey: string;
+  label: string;
+  executionStatus: InterventionExecutionStatus;
+  recommendation?: InterventionRecommendation;
+  strategyBlueprint?: InterventionStrategyBlueprint;
+  actionSummary?: InterventionActionSummary;
+  evidenceSummary?: InterventionEvidenceSummary;
+  historyContext: InterventionHistoryContext;
+  nextStep: ConceptCaseNextStep;
+  replayMetadata: {
+    recommendation: EngineReplaySummary;
+    transfer: EngineReplaySummary;
+  };
+}
+
+export function buildInterventionExecutionBundle(
+  bundle: ConceptCaseBundle,
+  conceptKey: string,
+): InterventionExecutionBundle {
+  const { recommendation, strategyBlueprint, history, nextStep, replayMetadata } = bundle;
+
+  const executionStatus: InterventionExecutionStatus = !recommendation
+    ? "no_intervention"
+    : recommendation.metadata.currentInterventionId
+      ? "active"
+      : "recommended";
+
+  const actionSummary: InterventionActionSummary | undefined = recommendation
+    ? {
+        action: recommendation.action,
+        strategy: recommendation.recommendedStrategy,
+        intensity: recommendation.suggestedIntensity,
+        confidence: recommendation.confidence,
+        priority: recommendation.priority,
+        summary: recommendation.summary,
+        decisionReason: recommendation.decisionReason,
+        requiresNewAssignment: recommendation.metadata.requiresNewAssignment,
+        requiresStrategyChange: recommendation.metadata.requiresStrategyChange,
+        transferFocus: recommendation.metadata.transferFocus,
+        currentInterventionId: recommendation.metadata.currentInterventionId,
+        currentInterventionStatus: recommendation.metadata.currentInterventionStatus,
+      }
+    : undefined;
+
+  const evidenceSummary: InterventionEvidenceSummary | undefined = recommendation
+    ? {
+        reasonCodes: recommendation.reasonCodes,
+        evidence: recommendation.evidence,
+        supportingSignals: recommendation.supportingSignals,
+        patternTypes: recommendation.metadata.patternTypes,
+        whyNotOtherActions: recommendation.whyNotOtherActions,
+      }
+    : undefined;
+
+  return {
+    conceptKey,
+    label: history.label,
+    executionStatus,
+    recommendation,
+    strategyBlueprint,
+    actionSummary,
+    evidenceSummary,
+    historyContext: {
+      diagnosisCount: history.diagnosisCount,
+      recurrenceCount: history.recurrenceCount,
+      recoveryStage: history.recoveryStage,
+      interventionCount: history.interventionHistorySummary.total,
+      activeCount: history.interventionHistorySummary.active,
+      improvedCount: history.interventionOutcomeSummary.improvedCount,
+      failedCount: history.interventionOutcomeSummary.failedCount,
+      latestStatus: history.interventionHistorySummary.latestStatus,
+      recurringLeak: history.recurringLeak,
+    },
+    nextStep,
+    replayMetadata,
+  };
+}


### PR DESCRIPTION
## Summary
- add intervention execution adapter and API
- add execution screen and route
- link concept detail to execution flow
- keep UI render-only and use canonical data

## Verification
- pnpm exec tsc --noEmit
- pnpm test
- pnpm --filter @poker-coach/table-sim build