### PR TITLE
feat: add live cash curriculum pack 2

### DIFF
--- a/content/drills/live_cash_exploit.json
+++ b/content/drills/live_cash_exploit.json
@@ -1,0 +1,229 @@
+[
+  {
+    "drill_id": "lc2_exp01_01",
+    "node_id": "exploit_01",
+    "version": "1.0.0",
+    "title": "Bluff-Catch Width vs Under-Bluffing Live Rec",
+    "prompt": "$2/$5 live. SRP, you defend BB vs BTN. Board: J♦8♣4♠2♥7♦ (runout bricked). You hold Q♣J♠ (TPWK). Villain (passive rec VPIP 70%) fires $80 into $100 on the river. Call or fold?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "river",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BB",
+      "villain_position": "BTN",
+      "hero_hand": ["Qc", "Js"],
+      "effective_stack_bb": 90,
+      "board": {
+        "flop": ["Jd", "8c", "4s"],
+        "turn": "2h",
+        "river": "7d"
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "bet", "size_pct_pot": 50 },
+        { "street": "flop", "player": "BB", "action": "call" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "BTN", "action": "check" },
+        { "street": "river", "player": "BB", "action": "check" },
+        { "street": "river", "player": "BTN", "action": "bet", "size_pct_pot": 80 }
+      ]
+    },
+    "decision_point": {
+      "street": "river",
+      "facing": { "action": "bet", "size_pct_pot": 80 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Fold" },
+      { "key": "CALL", "label": "Call" },
+      { "key": "RAISE", "label": "Raise" }
+    ],
+    "answer": {
+      "correct": "FOLD",
+      "accepted": [],
+      "required_tags": ["live_exploit_framing"],
+      "explanation": "This is the core live exploit framing decision: passive recs almost never fire large river bets as bluffs. Their range after checking the turn and firing the river is heavily value-weighted — two pairs, sets, occasionally strong TP. TPWK is a clear fold. Adjust your bluff-catch frequency down vs passive live pools."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": ["FOLD"],
+        "required_tags": ["live_exploit_framing"],
+        "explanation": "Competent reg range-balances river — their large bet includes bluffs with missed draws. TPWK is a reasonable bluff-catcher here. Call, but it's close."
+      },
+      "B": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["live_exploit_framing"],
+        "explanation": "Passive rec (Pool B) checked back the turn and now fires large river. Their river betting range is almost exclusively value — two pairs, sets, 87s. TPWK is dominated. Fold and save the chips."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["live_exploit_framing"],
+        "explanation": "Nit (Pool C) almost never fires river bets without a strong holding. River bet = the nit has you beat. Fold TPWK immediately."
+      }
+    },
+    "tags": ["street:river", "pot:srp", "position:oop", "spot:bb_vs_btn"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": [
+        "Calling TPWK against any large river bet because 'they could be bluffing'",
+        "Applying GTO bluff-catch frequency to passive live pools who rarely bluff rivers"
+      ],
+      "live_pool_notes": "Live passive recs (Pool B) are structurally under-bluffing at rivers. Their large river bets are almost always thin-to-strong value. Narrow your calling range vs their river actions — fold hands you'd call against online regs or aggressive players."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_exp01_02",
+    "node_id": "exploit_01",
+    "version": "1.0.0",
+    "title": "Thin Value Width vs Over-Calling Pay-Off Station",
+    "prompt": "$2/$5 live. SRP, IP. Board: Q♣9♦4♠2♥6♣ (full runout, dry). Villain (passive rec VPIP 60%, calls too wide) checks river. Hero holds 9♠8♦ (second pair, no kicker). Check back or bet?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "river",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["9s", "8d"],
+      "effective_stack_bb": 85,
+      "board": {
+        "flop": ["Qc", "9d", "4s"],
+        "turn": "2h",
+        "river": "6c"
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "bet", "size_pct_pot": 50 },
+        { "street": "flop", "player": "BB", "action": "call" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "BTN", "action": "check" },
+        { "street": "river", "player": "BB", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "river",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/3 pot)" },
+      { "key": "RAISE", "label": "Bet Medium (~1/2 pot)" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": [],
+      "required_tags": ["live_exploit_framing", "river_thin_value"],
+      "explanation": "Against an over-calling pool, second pair on a dry runout is a thin value bet. Villain's river check after calling flop includes 9x-worse, 6x pairs, missed gutshots, and floats. A small bet extracts from the bottom of their calling range. Against normal ranges you'd check back; against over-callers you widen your value range."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": ["CALL"],
+        "required_tags": ["live_exploit_framing"],
+        "explanation": "Competent player's river check range includes slow-played Qx hands and sets. Second pair is borderline. Checking back is safer — thin bet if you're confident they float a lot."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["live_exploit_framing", "river_thin_value"],
+        "explanation": "Pool B over-calls with any pair. Second pair (9x) is ahead of most of their checking range: 6x, 4x pairs, ace-high floats, missed draws. Bet small and get paid."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["live_exploit_framing"],
+        "explanation": "Tight Pool C only continues with better hands. Their river check likely includes traps or strong pairs. Second pair is not a value bet here — check back."
+      }
+    },
+    "tags": ["street:river", "pot:srp", "position:ip", "spot:btn_vs_bb"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": [
+        "Checking back second pair automatically because 'it's too thin'",
+        "Using the same value-bet threshold for all pools regardless of calling tendencies"
+      ],
+      "live_pool_notes": "Pool B players are structural over-callers. They call with bottom pair, any piece of the board, missed draws. This widens your value-bet range significantly. Second pair becomes a value bet on dry runouts when you identify an over-caller. The key adjustment: against over-callers, ask 'can they call with worse?' — if yes, bet."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_exp01_03",
+    "node_id": "exploit_01",
+    "version": "1.0.0",
+    "title": "ISO Sizing vs Under-Raising Passive Table",
+    "prompt": "$2/$5 live. UTG, UTG1, MP, HJ, CO all limp. You are BTN with A♠9♦ (100bb). Table profile: nobody has 3-bet or squeezed in 90 minutes. Limp behind, ISO standard (4x), or ISO big (7x)?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "preflop",
+      "pot_type": "limp",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "CO",
+      "hero_hand": ["As", "9d"],
+      "effective_stack_bb": 100,
+      "action_history": [
+        { "street": "preflop", "player": "UTG", "action": "limp", "size_bb": 1 },
+        { "street": "preflop", "player": "UTG1", "action": "limp", "size_bb": 1 },
+        { "street": "preflop", "player": "MP", "action": "limp", "size_bb": 1 },
+        { "street": "preflop", "player": "HJ", "action": "limp", "size_bb": 1 },
+        { "street": "preflop", "player": "CO", "action": "limp", "size_bb": 1 }
+      ]
+    },
+    "decision_point": {
+      "street": "preflop",
+      "facing": { "action": "limp", "size_bb": 1 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Limp Behind" },
+      { "key": "CALL", "label": "ISO 4x (standard size)" },
+      { "key": "RAISE", "label": "ISO 7x+ (exploit size)" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": ["CALL"],
+      "required_tags": ["live_exploit_framing", "iso_raise_live"],
+      "explanation": "Against a passive under-raising table, you can size your ISO significantly larger than standard without fear of a squeeze. No 3-bets or squeezes in 90 minutes = the table is under-raising. ISO to 7x+ (35bb at $2/$5) to get heads-up IP and build a large pot against dominated hands. Standard sizing still works; exploit sizing extracts maximum EV."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["live_exploit_framing"],
+        "explanation": "Mixed-skill table may have one or two squeeze-capable players. Standard ISO (4-5x) is safer — don't oversize vs a table that might squeeze. A9o plays fine from BTN HU at standard sizing."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": ["CALL"],
+        "required_tags": ["live_exploit_framing", "iso_raise_live"],
+        "explanation": "Pure passive limpers — zero squeeze risk. ISO large (6-8x) to get HU IP with A9o. They fold or flat at this size; nobody squeezes you. This is the core exploit: under-raising pool = no squeeze risk = you can price out multiple callers with a big ISO."
+      },
+      "C": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["live_exploit_framing"],
+        "explanation": "Nit Pool C has mostly weak hands in limping range, but some nits will over-limp premiums and trap. Standard ISO size is safer — don't bet 7x into a lineup that might have AA/KK slow-playing UTG."
+      }
+    },
+    "tags": ["street:preflop", "pot:limp", "position:ip", "spot:btn_iso_5way"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": [
+        "Using standard ISO sizing on tables where no squeeze threat exists",
+        "Limping behind premium hands to avoid 'risking chips' when ISO is the dominant play"
+      ],
+      "live_pool_notes": "Under-raising pools have no squeeze mechanism. Their response to your ISO is: fold or flat. When nobody at the table 3-bets or squeezes, you can size up to 7-8x as an ISO raise without blowing up your range. This forces out the spec hands that beat you in multiway pots and builds a large IP pot vs a dominated hand. Track table 3-bet frequency — zero 3-bets in 45+ minutes = under-raising table = size up."
+    },
+    "metadata": { "source": "manual" }
+  }
+]

--- a/content/drills/live_cash_pack2.json
+++ b/content/drills/live_cash_pack2.json
@@ -1,0 +1,2135 @@
+[
+  {
+    "drill_id": "lc2_iso01_01",
+    "node_id": "iso_01",
+    "version": "1.0.0",
+    "title": "CO Iso-Raise vs 3 Limpers — KJo",
+    "prompt": "$2/$5 live. UTG, UTG+1, and HJ all limp. You are CO with K♥J♦ (100bb). Iso-raise, limp behind, or fold?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "preflop",
+      "pot_type": "limp",
+      "players_to_flop": 2,
+      "hero_position": "CO",
+      "villain_position": "HJ",
+      "hero_hand": ["Kh", "Jd"],
+      "effective_stack_bb": 100,
+      "action_history": [
+        { "street": "preflop", "player": "UTG", "action": "limp", "size_bb": 1 },
+        { "street": "preflop", "player": "UTG1", "action": "limp", "size_bb": 1 },
+        { "street": "preflop", "player": "HJ", "action": "limp", "size_bb": 1 }
+      ]
+    },
+    "decision_point": {
+      "street": "preflop",
+      "facing": { "action": "limp", "size_bb": 1 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Fold" },
+      { "key": "CALL", "label": "Limp Behind" },
+      { "key": "RAISE", "label": "Iso-Raise" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": [],
+      "required_tags": ["iso_raise_live"],
+      "explanation": "KJo is a strong iso-raise candidate from CO vs passive live limpers. Size to 5-6x (25-30) to get heads-up IP. Limping behind concedes initiative and inflates a multiway pot with a hand that plays better HU."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["iso_raise_live"],
+        "explanation": "Pool A may flat or 3-bet iso-raises, but KJo is still strong enough to iso from CO. Size up to deny squeeze callers."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["iso_raise_live"],
+        "explanation": "Pool B passive limpers fold to ISO or call one at a time. Get HU with KJo IP — clear iso-raise."
+      },
+      "C": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["iso_raise_live"],
+        "explanation": "Pool C aggro players may squeeze, but KJo still iso-raises profitably from CO. Be prepared for a squeeze and have a plan."
+      }
+    },
+    "tags": ["street:preflop", "pot:limp", "position:ip", "spot:co_vs_limpers"],
+    "difficulty": 1,
+    "coaching_context": {
+      "common_mistakes": ["Limping behind with strong hands, forfeiting initiative", "Under-sizing iso-raise and getting multiple callers"],
+      "population_note": "Live limpers often fold to large iso-raises or call with dominated hands — both outcomes are profitable for KJo."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_iso01_02",
+    "node_id": "iso_01",
+    "version": "1.0.0",
+    "title": "BTN Iso-Raise vs 2 Limpers — A9o",
+    "prompt": "$2/$5 live. MP and CO limp. You are BTN with A♣9♦ (100bb). Iso-raise to 4-5x or limp?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "preflop",
+      "pot_type": "limp",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "CO",
+      "hero_hand": ["Ac", "9d"],
+      "effective_stack_bb": 100,
+      "action_history": [
+        { "street": "preflop", "player": "MP", "action": "limp", "size_bb": 1 },
+        { "street": "preflop", "player": "CO", "action": "limp", "size_bb": 1 }
+      ]
+    },
+    "decision_point": {
+      "street": "preflop",
+      "facing": { "action": "limp", "size_bb": 1 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Fold" },
+      { "key": "CALL", "label": "Limp Behind" },
+      { "key": "RAISE", "label": "Iso-Raise" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": [],
+      "required_tags": ["iso_raise_live"],
+      "explanation": "A9o on BTN vs 2 passive limpers is a textbook iso-raise. You have position, a top-pair-capable hand, and dominated limpers. Raise to 4-5x to get heads-up."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["iso_raise_live"],
+        "explanation": "Competent players may 3-bet iso-raises from the blinds — A9o has good enough equity to continue. Still iso."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["iso_raise_live"],
+        "explanation": "Passive recs limp-call dominated hands constantly. Iso-raise A9o for value IP — this is free money."
+      },
+      "C": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["iso_raise_live"],
+        "explanation": "Even aggro pools iso-raise A9o profitably from BTN. Their 3-bets don't dominate A9o often enough to deter."
+      }
+    },
+    "tags": ["street:preflop", "pot:limp", "position:ip", "spot:btn_vs_limpers"],
+    "difficulty": 1,
+    "coaching_context": {
+      "common_mistakes": ["Limping A9o behind and surrendering positional edge", "Over-folding in fear of 3-bet squeezes"],
+      "population_note": "A9o crushes passive limper ranges. Iso-raise is mandatory — every limp-behind costs expected value."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_iso01_03",
+    "node_id": "iso_01",
+    "version": "1.0.0",
+    "title": "BTN Facing 4 Limpers — 87s, Iso or Limp?",
+    "prompt": "$2/$5 live. UTG, UTG+1, HJ, and CO all limp. You are BTN with 8♠7♠ (100bb). Iso-raise to 7x or limp behind?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "preflop",
+      "pot_type": "limp",
+      "players_to_flop": 3,
+      "hero_position": "BTN",
+      "villain_position": "CO",
+      "hero_hand": ["8s", "7s"],
+      "effective_stack_bb": 100,
+      "action_history": [
+        { "street": "preflop", "player": "UTG", "action": "limp", "size_bb": 1 },
+        { "street": "preflop", "player": "UTG1", "action": "limp", "size_bb": 1 },
+        { "street": "preflop", "player": "HJ", "action": "limp", "size_bb": 1 },
+        { "street": "preflop", "player": "CO", "action": "limp", "size_bb": 1 }
+      ]
+    },
+    "decision_point": {
+      "street": "preflop",
+      "facing": { "action": "limp", "size_bb": 1 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Fold" },
+      { "key": "CALL", "label": "Limp Behind" },
+      { "key": "RAISE", "label": "Iso-Raise to 7x" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": [],
+      "required_tags": ["iso_raise_live", "multiway_context"],
+      "explanation": "With 4 limpers, iso-raising 87s bloats the pot multiway even vs a 7x size. 87s is a speculative suited connector that thrives with implied odds and position. Limp behind, see a cheap multiway flop, and extract big when you hit."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["iso_raise_live", "multiway_context"],
+        "explanation": "Competent players recognize 4-limper spots favor limping behind with speculative hands. Iso-raise inflates pot vs too many opponents."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["iso_raise_live", "multiway_context"],
+        "explanation": "Passive limpers rarely fold to even large iso-raises with 4 players in. Limp, get your implied odds, and flop big."
+      },
+      "C": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["iso_raise_live", "multiway_context"],
+        "explanation": "Aggro pool in the blinds can squeeze a 7x iso-raise, putting 87s in an awful spot. Limp behind and avoid the squeeze."
+      }
+    },
+    "tags": ["street:preflop", "pot:limp", "position:ip", "spot:btn_vs_limpers", "decision:iso_sizing"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Iso-raising every limped pot regardless of how many limpers", "Sizing too small vs 4 limpers and getting called by everyone"],
+      "population_note": "The iso-raise threshold tightens sharply with 4+ limpers. Suited connectors prefer multiway implied-odds spots over being the isolation aggressor."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_iso02_01",
+    "node_id": "iso_02",
+    "version": "1.0.0",
+    "title": "Iso Pot IP — Blank Turn After Checking Back Dry Flop",
+    "prompt": "BTN iso-raised 3 limpers to $30. Only CO called. Flop K♦7♣2♠ — BTN checks back. Turn: 4♦ (blank). CO checks. You have K♣J♠. Fire the delayed c-bet?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "CO",
+      "hero_hand": ["Kc", "Js"],
+      "effective_stack_bb": 94,
+      "board": {
+        "flop": ["Kd", "7c", "2s"],
+        "turn": "4d",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "raise", "size_bb": 6 },
+        { "street": "preflop", "player": "CO", "action": "call", "size_bb": 6 },
+        { "street": "flop", "player": "CO", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" },
+        { "street": "turn", "player": "CO", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/3 pot)" },
+      { "key": "RAISE", "label": "Bet Big (~2/3 pot)" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": ["CALL"],
+      "required_tags": ["delayed_cbet"],
+      "explanation": "Classic delayed c-bet with TPTK on a dry board. CO checked twice — their range is capped to weak pairs and floats. Fire 2/3 pot: extract value from Kx-worse, 7x, and deny any backdoor equity."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Competent players may have slow-played Kx or 77/22 — use medium sizing (1/2 pot) to extract value without over-building the pot with TPTK."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": ["CALL"],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Passive recs check-call with Kx-worse, 7x, even naked gutshots. Bet 2/3 pot for maximum value — their range is capped and sticky."
+      },
+      "C": {
+        "correct": "RAISE",
+        "accepted": ["CALL"],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Aggro pool players also show down weak holdings after two checks. Bet big and fold out their air-heavy range."
+      }
+    },
+    "tags": ["street:turn", "pot:srp", "position:ip", "spot:delayed_cbet", "decision:barrel"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Checking back the turn again and giving free cards", "Betting too small and allowing floats to realize equity cheaply"],
+      "population_note": "Two checks from a passive rec signals weakness. The delayed c-bet is the primary value extraction tool in iso pots — don't sleep through it."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_iso02_02",
+    "node_id": "iso_02",
+    "version": "1.0.0",
+    "title": "Iso Pot IP — Flush Completes on Turn After Checking Flop",
+    "prompt": "BTN iso-raised to $25. CO called. Flop J♥6♣2♠ — BTN checked back with K♠Q♠ (nut flush draw). Turn: 4♠ (flush completes). CO checks. Hero made the nut flush. Bet?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "CO",
+      "hero_hand": ["Ks", "Qs"],
+      "effective_stack_bb": 95,
+      "board": {
+        "flop": ["Jh", "6c", "2s"],
+        "turn": "4s",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "raise", "size_bb": 5 },
+        { "street": "preflop", "player": "CO", "action": "call", "size_bb": 5 },
+        { "street": "flop", "player": "CO", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" },
+        { "street": "turn", "player": "CO", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/3 pot)" },
+      { "key": "RAISE", "label": "Bet Large (~2/3 pot or more)" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": [],
+      "required_tags": ["delayed_cbet"],
+      "explanation": "Hero has the nut flush and CO checked. Bet large — CO's range is capped to Jx, 6x, and occasional floats. The nut flush is a building hand; extract maximum value now before the river might kill action."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Competent players may hold Ax♠ as a float. Medium sizing invites action and sets up river shove."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Passive recs never fold Jx or Ax facing a turn bet. Bet 2/3-3/4 pot and set up a river value bet."
+      },
+      "C": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Gambly pool players call off stack with top pair. Build pot aggressively with nut flush."
+      }
+    },
+    "tags": ["street:turn", "pot:srp", "position:ip", "spot:delayed_cbet", "decision:value_bet"],
+    "difficulty": 1,
+    "coaching_context": {
+      "common_mistakes": ["Slowplaying the nut flush and giving CO a free river", "Betting too small and allowing river to kill action"],
+      "population_note": "Nut-flush on turn is a value emergency — build now. Live recs pay off top pair vs flush-completing boards far too often."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_iso02_03",
+    "node_id": "iso_02",
+    "version": "1.0.0",
+    "title": "Iso Pot IP — Turn Pairs the Top Card, Hits Villain Range",
+    "prompt": "BTN iso-raised to $30. CO called. Flop T♠7♣3♦ — checked through. Turn T♥ (top card pairs; hits CO's Tx range). CO checks. Hero has A♦Q♥ (no pair, no draw). Stab or check?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "CO",
+      "hero_hand": ["Ad", "Qh"],
+      "effective_stack_bb": 94,
+      "board": {
+        "flop": ["Ts", "7c", "3d"],
+        "turn": "Th",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "raise", "size_bb": 6 },
+        { "street": "preflop", "player": "CO", "action": "call", "size_bb": 6 },
+        { "street": "flop", "player": "CO", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" },
+        { "street": "turn", "player": "CO", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/3 pot)" },
+      { "key": "RAISE", "label": "Barrel (~2/3 pot)" }
+    ],
+    "answer": {
+      "correct": "FOLD",
+      "accepted": [],
+      "required_tags": ["delayed_cbet"],
+      "explanation": "The paired T improves CO's limp-calling range (Tx trips, Tx two-pair). Hero has AQ with no pair, no draw — no equity, no fold equity. Checking back preserves showdown value and avoids a check-raise bluff-catch situation."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Competent player may check-raise the turn with trips. AQ has reverse implied odds — check and reassess river."
+      },
+      "B": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Passive recs call down with Tx on paired boards. Bluffing has no merit — check back AQ and take showdown when river blanks."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Aggro pool may check-raise the T — AQ can't continue. Check back and give up unless the river provides equity."
+      }
+    },
+    "tags": ["street:turn", "pot:srp", "position:ip", "spot:no_cbet", "decision:give_up"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Auto-stabbing turn after any two-check sequence regardless of board texture", "Bluffing into a board that dramatically improves villain's range"],
+      "population_note": "The delayed c-bet requires a range-awareness check. When the turn improves the calling range, checking back is not passive — it's correct."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_bb01_01",
+    "node_id": "bb_01",
+    "version": "1.0.0",
+    "title": "BB Defend vs BTN Open — K9o",
+    "prompt": "$2/$5 live. Folds to BTN who opens to $15 (3bb). You are BB with K♣9♦ (100bb). Call, fold, or 3-bet?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "preflop",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BB",
+      "villain_position": "BTN",
+      "hero_hand": ["Kc", "9d"],
+      "effective_stack_bb": 100,
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 }
+      ]
+    },
+    "decision_point": {
+      "street": "preflop",
+      "facing": { "action": "open", "size_bb": 3 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Fold" },
+      { "key": "CALL", "label": "Call" },
+      { "key": "RAISE", "label": "3-Bet" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": [],
+      "required_tags": ["bb_defend_live"],
+      "explanation": "K9o is a comfortable BB defend vs a standard BTN 3x open in a live pool. The pot odds are favorable (calling 2bb into a 4.5bb pot) and K9o has enough equity vs a wide BTN range to realize post-flop."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "BTN opens wide vs BB — K9o has fine equity and position isn't a huge disadvantage in live games. Call and play post-flop."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Passive BTN opens a wide range but rarely 4-bets — calling K9o is standard and profitable."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": ["CALL"],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Tight aggro BTN opens a value-heavy range. K9o is dominated often enough that folding becomes correct. Calling is a modest error."
+      }
+    },
+    "tags": ["street:preflop", "pot:srp", "position:oop", "spot:bb_vs_btn"],
+    "difficulty": 1,
+    "coaching_context": {
+      "common_mistakes": ["Over-folding BB vs wide BTN opens, surrendering pot equity", "3-betting K9o without a clear exploit reason"],
+      "population_note": "Live BTN ranges are wide vs BB. K9o defends comfortably. Folding is giving up free equity."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_bb01_02",
+    "node_id": "bb_01",
+    "version": "1.0.0",
+    "title": "BB Defend vs BTN Open — T8s",
+    "prompt": "$2/$5 live. Folds to BTN who opens to $15 (3bb). You are BB with T♥8♥ (100bb). Call or fold?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "preflop",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BB",
+      "villain_position": "BTN",
+      "hero_hand": ["Th", "8h"],
+      "effective_stack_bb": 100,
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 }
+      ]
+    },
+    "decision_point": {
+      "street": "preflop",
+      "facing": { "action": "open", "size_bb": 3 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Fold" },
+      { "key": "CALL", "label": "Call" },
+      { "key": "RAISE", "label": "3-Bet" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": [],
+      "required_tags": ["bb_defend_live"],
+      "explanation": "T8s in the BB vs a standard BTN open is a defend. The suited connector has strong implied odds, good blockers, and thrives in deep live games. Folding surrenders too much equity to a wide range."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "BTN opens wide — T8s defends comfortably. Implied odds are strong at 100bb."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Passive BTN rarely fires multiple streets — T8s has great implied odds against their top-pair-heavy value regions."
+      },
+      "C": {
+        "correct": "CALL",
+        "accepted": ["FOLD"],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Tight BTN narrows the range, making T8s implied odds slightly thinner. Calling is still fine; folding is marginal."
+      }
+    },
+    "tags": ["street:preflop", "pot:srp", "position:oop", "spot:bb_vs_btn"],
+    "difficulty": 1,
+    "coaching_context": {
+      "common_mistakes": ["Folding T8s out of fear of being OOP", "Over-estimating the positional disadvantage for live cash at 100bb"],
+      "population_note": "Suited connectors in the BB are strong defends vs wide BTN ranges. The implied odds at live stakes more than compensate for the positional disadvantage."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_bb01_03",
+    "node_id": "bb_01",
+    "version": "1.0.0",
+    "title": "BB vs BTN 4x Open — QJo, Call or 3-Bet?",
+    "prompt": "$2/$5 live. BTN opens to $20 (4bb) — larger than standard. You are BB with Q♠J♥ (100bb). Fold, call, or 3-bet?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "preflop",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BB",
+      "villain_position": "BTN",
+      "hero_hand": ["Qs", "Jh"],
+      "effective_stack_bb": 100,
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 4 }
+      ]
+    },
+    "decision_point": {
+      "street": "preflop",
+      "facing": { "action": "open", "size_bb": 4 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Fold" },
+      { "key": "CALL", "label": "Call" },
+      { "key": "RAISE", "label": "3-Bet" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": ["RAISE"],
+      "required_tags": ["bb_defend_live"],
+      "explanation": "QJo is a strong enough hand to defend vs most BTN opens. Calling is default — flat and play post-flop. 3-betting is viable as an exploit if BTN folds too often, but QJo doesn't have the blocker structure for a pure 3-bet bluff."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Competent BTN 4-bets strong holdings, making QJo a better call than 3-bet. Realize equity post-flop."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": ["CALL"],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Passive BTN rarely 4-bets. 3-betting QJo exploits their fold-to-3-bet tendency. Calling is also fine."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": ["CALL"],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Tight BTN raises a value-heavy range. QJo is dominated often enough that folding is correct. Calling is a modest mistake."
+      }
+    },
+    "tags": ["street:preflop", "pot:srp", "position:oop", "spot:bb_vs_btn", "decision:3bet_or_flat"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Auto-3-betting QJo without considering BTN's 4-bet range", "Folding QJo to a 4bb open in live games"],
+      "population_note": "The default is to call with QJo in BB. The 3-bet exploit is only justified when the BTN over-folds to 3-bets — know your player before blasting."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_bb02_01",
+    "node_id": "bb_02",
+    "version": "1.0.0",
+    "title": "BB vs SB Limp — J8o, Check or Raise?",
+    "prompt": "$2/$5 live. Folds to SB who limps. You are BB with J♦8♠ (100bb). Check or raise?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "preflop",
+      "pot_type": "limp",
+      "players_to_flop": 2,
+      "hero_position": "BB",
+      "villain_position": "SB",
+      "hero_hand": ["Jd", "8s"],
+      "effective_stack_bb": 100,
+      "action_history": [
+        { "street": "preflop", "player": "SB", "action": "limp", "size_bb": 1 }
+      ]
+    },
+    "decision_point": {
+      "street": "preflop",
+      "facing": { "action": "limp", "size_bb": 1 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check" },
+      { "key": "CALL", "label": "Raise Small (~3bb)" },
+      { "key": "RAISE", "label": "Raise Large (~5bb)" }
+    ],
+    "answer": {
+      "correct": "FOLD",
+      "accepted": ["CALL"],
+      "required_tags": ["bb_defend_live"],
+      "explanation": "J8o vs SB limp can check or raise small. Checking is fine — see a free flop, play well post. J8o doesn't need to raise here as a default, though a small raise is acceptable as an exploit when SB is passive."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "SB's limping range is unclear — checking with J8o avoids inflating the pot OOP with a marginal hand."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": ["FOLD"],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Passive SB rarely plays back to a BB raise. J8o raises small for pot control and information."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Aggro SB may 3-bet a BB raise. Checking J8o avoids the squeeze and keeps a cheap pot."
+      }
+    },
+    "tags": ["street:preflop", "pot:limp", "position:ip", "spot:bb_vs_sb_limp"],
+    "difficulty": 1,
+    "coaching_context": {
+      "common_mistakes": ["Over-raising marginal hands vs SB limps, building a big pot OOP", "Under-raising when SB is consistently passive and exploitable"],
+      "population_note": "BB is IP vs SB in a limped pot — this is one of the few spots BB has position. Checking is the default; small raising is a reasonable exploit vs passive SBs."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_bb02_02",
+    "node_id": "bb_02",
+    "version": "1.0.0",
+    "title": "BB vs SB 3x Steal — A5o, Defend or Fold?",
+    "prompt": "$2/$5 live. Folds to SB who raises to $15 (3bb). You are BB with A♣5♦ (100bb). Fold, call, or 3-bet?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "preflop",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BB",
+      "villain_position": "SB",
+      "hero_hand": ["Ac", "5d"],
+      "effective_stack_bb": 100,
+      "action_history": [
+        { "street": "preflop", "player": "SB", "action": "raise", "size_bb": 3 }
+      ]
+    },
+    "decision_point": {
+      "street": "preflop",
+      "facing": { "action": "raise", "size_bb": 3 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Fold" },
+      { "key": "CALL", "label": "Call" },
+      { "key": "RAISE", "label": "3-Bet" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": ["RAISE"],
+      "required_tags": ["bb_defend_live"],
+      "explanation": "A5o is a standard BB defend vs a SB 3x steal. You have an ace-high hand with equity vs a wide SB stealing range. Call and play post-flop. 3-betting is a viable semi-bluff if SB folds frequently to 3-bets."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Wide SB steal range — A5o has live equity. Call and play post-flop. 3-betting risks being dominated."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": ["CALL"],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Passive SB folds too often to 3-bets. A5o is a strong 3-bet bluff candidate — exploit fold equity."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": ["CALL"],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Tight SB raises a value-heavy range. A5o is often dominated. Folding is correct; calling is a modest mistake."
+      }
+    },
+    "tags": ["street:preflop", "pot:srp", "position:oop", "spot:bb_vs_sb_raise"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Folding A5o to a standard SB steal, conceding too much", "3-betting without any read on SB's fold-to-3-bet frequency"],
+      "population_note": "SB steals wide in live cash. A5o has ace-high equity and a wheel blocker — standard defend. Adjust to 3-bet exploit only when you have a confirmed passive profile on SB."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_bb02_03",
+    "node_id": "bb_02",
+    "version": "1.0.0",
+    "title": "BB vs SB Limp — KQo, Raise or Check?",
+    "prompt": "$2/$5 live. SB limps. You are BB with K♥Q♦ (100bb). Check or raise?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "preflop",
+      "pot_type": "limp",
+      "players_to_flop": 2,
+      "hero_position": "BB",
+      "villain_position": "SB",
+      "hero_hand": ["Kh", "Qd"],
+      "effective_stack_bb": 100,
+      "action_history": [
+        { "street": "preflop", "player": "SB", "action": "limp", "size_bb": 1 }
+      ]
+    },
+    "decision_point": {
+      "street": "preflop",
+      "facing": { "action": "limp", "size_bb": 1 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check" },
+      { "key": "CALL", "label": "Raise Small (~3bb)" },
+      { "key": "RAISE", "label": "Raise Large (~5-6bb)" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": ["CALL"],
+      "required_tags": ["bb_defend_live"],
+      "explanation": "KQo is too strong to check vs a SB limp. Raise to 4-5bb to get value from a dominated SB range and play a bigger pot with a strong hand. Checking gives away a free flop with a premium holding."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Competent SB may have limped strong hands. Raise small to get information; don't bloat the pot without knowing their range."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": ["CALL"],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Passive SB limps wide — KQo dominates most of their range. Raise to 5bb and play a bigger pot in position."
+      },
+      "C": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["bb_defend_live"],
+        "explanation": "Aggro SB may 3-bet, but KQo calls and plays a 3-bet pot fine. Still raise — don't give free flops."
+      }
+    },
+    "tags": ["street:preflop", "pot:limp", "position:ip", "spot:bb_vs_sb_limp", "decision:bb_iso"],
+    "difficulty": 1,
+    "coaching_context": {
+      "common_mistakes": ["Checking KQo vs SB limp and giving away a free flop", "Under-raising KQo when the BB has IP advantage vs SB"],
+      "population_note": "BB is IP vs SB. KQo is a mandatory raise — checking is a significant leak that surrenders EV with a dominant hand."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_srp06_01",
+    "node_id": "srp_06",
+    "version": "1.0.0",
+    "title": "Delayed C-Bet IP — Blank Turn After Dry Flop Check-Through",
+    "prompt": "BTN opened, BB called. Flop K♦5♣2♠ (very dry). BTN checks back. Turn: 3♥ (blank). BB checks. Hero (BTN) has A♠K♥ (TPTK). Fire the delayed c-bet?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["As", "Kh"],
+      "effective_stack_bb": 97,
+      "board": {
+        "flop": ["Kd", "5c", "2s"],
+        "turn": "3h",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" },
+        { "street": "turn", "player": "BB", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/3 pot)" },
+      { "key": "RAISE", "label": "Bet 2/3 Pot" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": ["CALL"],
+      "required_tags": ["delayed_cbet"],
+      "explanation": "BB checked twice on a dry board — their range is capped to weak pairs and floats. Fire the delayed c-bet with TPTK. Bet 2/3 to extract value and deny any backdoor draws. Checking back again is too passive."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Competent BB may have slow-played a set. Bet 1/2 pot to extract value while managing the pot size with TPTK."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Passive BB's double-check range is very weak. Bet 2/3 pot — they call with every Kx-worse and most pairs."
+      },
+      "C": {
+        "correct": "RAISE",
+        "accepted": ["CALL"],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Aggro BB checked twice — even they are capped. Bet and fold them off their air or extract from weak made hands."
+      }
+    },
+    "tags": ["street:turn", "pot:srp", "position:ip", "spot:delayed_cbet", "decision:barrel"],
+    "difficulty": 1,
+    "coaching_context": {
+      "common_mistakes": ["Checking back TPTK on blank turns after two-check sequences", "Betting too small and allowing floats to chase cheap rivers"],
+      "population_note": "BB double-checking a K-high dry board is one of the clearest delayed c-bet triggers. Don't sleep through value with top pair top kicker."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_srp06_02",
+    "node_id": "srp_06",
+    "version": "1.0.0",
+    "title": "Delayed C-Bet IP — Nut Flush Draw Checks Flop, Flush Hits Turn",
+    "prompt": "BTN opened, BB called. Flop J♠7♠2♦ — BTN checked back with K♠Q♠ (nut flush draw). Turn 4♠ (flush completes). BB checks. Hero now has the nut flush. Bet?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["Ks", "Qs"],
+      "effective_stack_bb": 97,
+      "board": {
+        "flop": ["Js", "7s", "2d"],
+        "turn": "4s",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" },
+        { "street": "turn", "player": "BB", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Medium (~1/2 pot)" },
+      { "key": "RAISE", "label": "Bet Large (~3/4 pot)" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": ["CALL"],
+      "required_tags": ["delayed_cbet"],
+      "explanation": "Hero flopped the nut flush draw and made it on the turn. BB checked again — they may have Jx, Ax♠ floats, or two-pair. Build the pot now with a 3/4-pot bet to set up a river shove. Don't let the hand play small."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Competent BB may have Ax♠ and call a big turn bet. Medium sizing is fine — sets up river value."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Passive BB calls off with Jx, Ax♠, even naked pairs on flush boards. Bet large and set up river extraction."
+      },
+      "C": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Aggro pool calls nutted hands or check-raises smaller — bet large to commit stacks with the best hand."
+      }
+    },
+    "tags": ["street:turn", "pot:srp", "position:ip", "spot:delayed_cbet", "decision:value_bet"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Slowplaying the nut flush after checking back a draw on the flop", "Betting too small and missing stack-building opportunity"],
+      "population_note": "You have the nuts and position — now is the time to build. The delayed c-bet with a nutted hand is a stack-building opportunity, not a trap setup."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_srp06_03",
+    "node_id": "srp_06",
+    "version": "1.0.0",
+    "title": "Delayed C-Bet IP — Turn Pairs Top Card, Hits BB Range",
+    "prompt": "BTN opened, BB called. Flop T♠7♦3♣ — checked through. Turn T♥ (pairs the top card). BB checks. Hero (BTN) has A♦Q♥ (no pair, no draw). Bluff or check?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["Ad", "Qh"],
+      "effective_stack_bb": 97,
+      "board": {
+        "flop": ["Ts", "7d", "3c"],
+        "turn": "Th",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" },
+        { "street": "turn", "player": "BB", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (bluff)" },
+      { "key": "RAISE", "label": "Barrel Big (bluff)" }
+    ],
+    "answer": {
+      "correct": "FOLD",
+      "accepted": [],
+      "required_tags": ["delayed_cbet"],
+      "explanation": "The T pairing the board significantly improves BB's BB defending range (Tx combos become trips). AQ has no equity and no fold equity against a range that has improved. Check back and take a free river — AQ has showdown value vs a complete bluff by the river."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Competent BB may check-raise the T with trips. AQ has zero equity after that — check back."
+      },
+      "B": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Passive BB calls down with Tx — bluffing has no merit. Check back and give up gracefully."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["delayed_cbet"],
+        "explanation": "Aggro BB check-raises the turn with Tx for value. AQ can't continue — check and fold to a lead."
+      }
+    },
+    "tags": ["street:turn", "pot:srp", "position:ip", "spot:no_cbet", "decision:give_up"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Firing the delayed c-bet mechanically on any two-check sequence", "Bluffing into boards that improved the calling range dramatically"],
+      "population_note": "Delayed c-bets require range awareness. A paired top card on the turn is a red flag — BB's range strengthened, not weakened. Check back."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_srp07_01",
+    "node_id": "srp_07",
+    "version": "1.0.0",
+    "title": "OOP Turn Probe — BTN Checks Flop, Blank Turn, TP Hero Leads",
+    "prompt": "BB called BTN open. Flop Q♣8♠4♦ — BTN checks back. Turn 2♣ (blank). Hero (BB) has Q♥T♦ (top pair decent kicker). Check or lead out?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BB",
+      "villain_position": "BTN",
+      "hero_hand": ["Qh", "Td"],
+      "effective_stack_bb": 97,
+      "board": {
+        "flop": ["Qc", "8s", "4d"],
+        "turn": "2c",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check" },
+      { "key": "CALL", "label": "Lead Small (~1/3 pot)" },
+      { "key": "RAISE", "label": "Lead Large (~2/3 pot)" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": ["FOLD"],
+      "required_tags": ["delayed_cbet", "probe_bet_turn"],
+      "explanation": "BTN checked back a Q-high flop — their range is capped to weak holdings, missed overs, or occasional slow-plays. Leading small with TPTK is a profitable probe to deny free cards and extract value. Large lead or check are also reasonable depending on pool read."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": ["CALL"],
+        "required_tags": ["delayed_cbet", "probe_bet_turn"],
+        "explanation": "Competent BTN may have slow-played Qx or flopped a set. Checking with TPTK gives you information — lead is a thin line."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["delayed_cbet", "probe_bet_turn"],
+        "explanation": "Passive BTN rarely raises when they're beat. Small lead extracts value from 8x, 4x, and air floats."
+      },
+      "C": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["delayed_cbet", "probe_bet_turn"],
+        "explanation": "Aggro BTN checks back range-wide sometimes. Small lead charges their equity — large lead risks fold from hands you beat."
+      }
+    },
+    "tags": ["street:turn", "pot:srp", "position:oop", "spot:oop_probe", "decision:lead_turn"],
+    "difficulty": 3,
+    "coaching_context": {
+      "common_mistakes": ["Checking top pair again after BTN shows weakness", "Leading too large and folding hands you beat"],
+      "population_note": "OOP probes are underutilized in live cash. When the BTN checks back a board that favors them, they've shown weakness — small leads exploit passive BTNs profitably."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_srp07_02",
+    "node_id": "srp_07",
+    "version": "1.0.0",
+    "title": "OOP Turn Probe — BTN Checks Flop, Air, Check or Bluff?",
+    "prompt": "BB called BTN open. Flop A♠9♦6♣ — BTN checks back. Turn 2♥ (blank). Hero (BB) has K♣T♣ (no pair, no draw). Check or probe-bluff?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BB",
+      "villain_position": "BTN",
+      "hero_hand": ["Kc", "Tc"],
+      "effective_stack_bb": 97,
+      "board": {
+        "flop": ["As", "9d", "6c"],
+        "turn": "2h",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check" },
+      { "key": "CALL", "label": "Probe Small (bluff)" },
+      { "key": "RAISE", "label": "Probe Large (bluff)" }
+    ],
+    "answer": {
+      "correct": "FOLD",
+      "accepted": [],
+      "required_tags": ["probe_bet_turn"],
+      "explanation": "Hero has no equity and no draw on an ace-high board. Bluffing OOP into a BTN range that often includes Ax (checked back for deception or on a dry flop) is poor bluff selection. Check and give up — take the free river, fold to any bet."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["probe_bet_turn"],
+        "explanation": "Competent BTN checks back Ax often — bluffing KTo into an A-high board is low fold equity. Check."
+      },
+      "B": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["probe_bet_turn"],
+        "explanation": "Passive BTN calls down with pairs — no fold equity with KTo. Check and take free river."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["probe_bet_turn"],
+        "explanation": "Aggro BTN may check-raise or call and barrel — probing with no equity is losing in both scenarios."
+      }
+    },
+    "tags": ["street:turn", "pot:srp", "position:oop", "spot:oop_probe", "decision:give_up"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Probe-bluffing with no equity or fold equity, burning chips", "Confusing BTN check-back (showing weakness) with a mandate to bluff"],
+      "population_note": "OOP bluffing requires fold equity. On an A-high board where BTN might have checked back Ax, KTo has none. Check and preserve stack."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_srp07_03",
+    "node_id": "srp_07",
+    "version": "1.0.0",
+    "title": "OOP Turn Lead — BTN Checks Flop, Hero Hits Nut Straight on Turn",
+    "prompt": "BB called BTN open. Flop J♣T♥5♦ — BTN checks back. Turn Q♠ (hero K♥9♦ makes nut straight). Hero leads or checks?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BB",
+      "villain_position": "BTN",
+      "hero_hand": ["Kh", "9d"],
+      "effective_stack_bb": 97,
+      "board": {
+        "flop": ["Jc", "Th", "5d"],
+        "turn": "Qs",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check (slowplay)" },
+      { "key": "CALL", "label": "Lead Medium (~1/2 pot)" },
+      { "key": "RAISE", "label": "Lead Large (~2/3-3/4 pot)" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": ["CALL"],
+      "required_tags": ["probe_bet_turn"],
+      "explanation": "Hero has the nut straight OOP. The turn Q♠ gives BTN many connected hands (KJ, AK) that will call a large lead. Build the pot now — a big OOP lead with the nuts is correct. Slowplaying risks a blank river killing action."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["probe_bet_turn"],
+        "explanation": "Competent BTN may fold to a large OOP lead — medium sizing builds the pot while keeping their range wide."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["probe_bet_turn"],
+        "explanation": "Passive BTN calls off with KJx, two-pair, sets — lead large and extract maximum from their sticky range."
+      },
+      "C": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["probe_bet_turn"],
+        "explanation": "Aggro BTN may raise the lead — that's fine, you have the nuts. Lead large and stack off."
+      }
+    },
+    "tags": ["street:turn", "pot:srp", "position:oop", "spot:oop_donk", "decision:value_lead"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Slowplaying the nut straight OOP and losing action on a blank river", "Leading too small and underbuilding with a strong hand"],
+      "population_note": "OOP value leads are underutilized. When BTN shows weakness and hero has the nuts on a connected board, lead big — BTN's J-T-Q connected range pays off."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_rv01_01",
+    "node_id": "river_01",
+    "version": "1.0.0",
+    "title": "River Thin Value — Second Pair on Dry Board vs Passive Rec",
+    "prompt": "SRP, IP. Board K♥7♣2♦4♠3♣ (very dry). Villain (passive rec) checks river. Hero has 7♦6♦ (second pair). Check back or bet for thin value?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "river",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["7d", "6d"],
+      "effective_stack_bb": 90,
+      "board": {
+        "flop": ["Kh", "7c", "2d"],
+        "turn": "4s",
+        "river": "3c"
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "bet", "size_pct_pot": 50 },
+        { "street": "flop", "player": "BB", "action": "call" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "BTN", "action": "check" },
+        { "street": "river", "player": "BB", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "river",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/3 pot)" },
+      { "key": "RAISE", "label": "Bet Large (~2/3 pot)" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": ["FOLD"],
+      "required_tags": ["river_thin_value"],
+      "explanation": "Second pair on a K-7-2-4-3 dry board is thin but viable vs a passive rec. They called flop and checked twice — their range includes 7x-worse, 2x, and busted straight draws. Small bet extracts from the bottom of their range. Check is also reasonable."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": ["CALL"],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Competent player's river check range includes hands that beat second pair. Check back — too thin."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": ["FOLD"],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Passive recs call river with pairs, 6x, busted draws. Small bet at 1/3 pot extracts from the bottom of their range."
+      },
+      "C": {
+        "correct": "CALL",
+        "accepted": ["FOLD"],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Aggro pool checks down more often on blank rivers — second pair small bet is a fine exploit."
+      }
+    },
+    "tags": ["street:river", "pot:srp", "position:ip", "spot:thin_value", "decision:river_value"],
+    "difficulty": 3,
+    "coaching_context": {
+      "common_mistakes": ["Betting second pair too large and getting called by better hands", "Always checking back thin hands and leaving value on the table"],
+      "population_note": "Live recs call river with a wide range of made hands. Second pair IP vs a passive player who checked twice is a small-bet spot — not a check-back by default."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_rv01_02",
+    "node_id": "river_01",
+    "version": "1.0.0",
+    "title": "River Thin Value — TPWK on Jack-High Board",
+    "prompt": "SRP, IP. Board J♠7♦3♣5♥2♦. Villain checked every street. Hero has J♥9♠ (TPWK). Bet or check?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "river",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["Jh", "9s"],
+      "effective_stack_bb": 92,
+      "board": {
+        "flop": ["Js", "7d", "3c"],
+        "turn": "5h",
+        "river": "2d"
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "BTN", "action": "check" },
+        { "street": "river", "player": "BB", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "river",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/3 pot)" },
+      { "key": "RAISE", "label": "Bet Medium (~1/2 pot)" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": [],
+      "required_tags": ["river_thin_value"],
+      "explanation": "Villain checked three streets — their range is capped to weak Jx, pairs under J, and missed draws. TPWK is ahead of most of that. Small bet at 1/3 pot extracts thin value while managing risk of check-raise from slow-played strong hands."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": ["CALL"],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Competent player checks back with stronger Jx hands sometimes. Check — too thin vs a thinking opponent."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Passive rec checks down with Jx-worse, 7x, even Ax air. Small bet wins often — extract it."
+      },
+      "C": {
+        "correct": "CALL",
+        "accepted": ["FOLD"],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Aggro pool also checks down with marginal holdings. Small probe to get called by worse Jx."
+      }
+    },
+    "tags": ["street:river", "pot:srp", "position:ip", "spot:thin_value", "decision:river_value"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Checking back TPWK on rivers where villain's range is capped by passive play", "Over-betting and getting called only by better hands"],
+      "population_note": "Triple-checked boards signal capped ranges. TPWK IP is a small-bet value spot in most live pools — the key is sizing down to maximize call frequency."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_rv01_03",
+    "node_id": "river_01",
+    "version": "1.0.0",
+    "title": "River Thin Value — TPNK, Size Up vs Passive Pool",
+    "prompt": "SRP, IP. Board A♣8♦5♥K♠2♣. Villain called flop c-bet, checked turn, checked river. Hero has A♦3♣ (TPNK). What sizing?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "river",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["Ad", "3c"],
+      "effective_stack_bb": 87,
+      "board": {
+        "flop": ["Ac", "8d", "5h"],
+        "turn": "Ks",
+        "river": "2c"
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "bet", "size_pct_pot": 60 },
+        { "street": "flop", "player": "BB", "action": "call" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "BTN", "action": "check" },
+        { "street": "river", "player": "BB", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "river",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/3 pot)" },
+      { "key": "RAISE", "label": "Bet Medium-Large (~1/2-2/3 pot)" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": ["CALL"],
+      "required_tags": ["river_thin_value", "merge_vs_passive"],
+      "explanation": "Villain called a flop c-bet and checked turn and river — their range is capped. TPNK is ahead of 8x, 5x, 2x, and Kx-without-ace. Bet medium-large: passive recs can't fold Ax-weaker, paired boards, or medium pairs. Extract maximum."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": ["FOLD"],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Competent player's flop call includes AJ+, 2P, sets — TPNK is thin vs their range. Bet small or check."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["river_thin_value", "merge_vs_passive"],
+        "explanation": "Passive rec calls with Ax, 8x, 5x — they cannot fold top pair. Size up to 2/3 pot and get paid."
+      },
+      "C": {
+        "correct": "RAISE",
+        "accepted": ["CALL"],
+        "required_tags": ["river_thin_value", "merge_vs_passive"],
+        "explanation": "Aggro pool calls down wide on blank runouts. Medium-large sizing extracts value from their calling range."
+      }
+    },
+    "tags": ["street:river", "pot:srp", "position:ip", "spot:thin_value_sizing", "decision:river_sizing"],
+    "difficulty": 3,
+    "coaching_context": {
+      "common_mistakes": ["Defaulting to small sizing with any thin value hand", "Checking back TPNK when villain's range is demonstrably capped"],
+      "population_note": "Against passive pools, TPNK can often size up on river when the runout is blank. Their capped range cannot fold top pair — exploit it."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_rv02_01",
+    "node_id": "river_02",
+    "version": "1.0.0",
+    "title": "River Sizing vs Sticky Pool — Strong Hand, Go Big",
+    "prompt": "SRP, IP. Board Q♠J♦9♣3♥2♠ (dry runout). Villain checks river. Hero has Q♥Q♣ (set of queens). What sizing?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "river",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["Qh", "Qc"],
+      "effective_stack_bb": 85,
+      "board": {
+        "flop": ["Qs", "Jd", "9c"],
+        "turn": "3h",
+        "river": "2s"
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "bet", "size_pct_pot": 40 },
+        { "street": "flop", "player": "BB", "action": "call" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "BTN", "action": "bet", "size_pct_pot": 50 },
+        { "street": "turn", "player": "BB", "action": "call" },
+        { "street": "river", "player": "BB", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "river",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Medium (~1/2 pot)" },
+      { "key": "RAISE", "label": "Bet Large (~pot or overbet)" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": [],
+      "required_tags": ["river_thin_value", "underfold_exploit"],
+      "explanation": "Hero has top set on a dry runout. Villain called two streets — their range includes QJ, JJ, 9x, and is sticky. Bet large or overbet: live recs cannot fold two pair or overpairs to large river bets. Maximize extraction."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Competent player may have QJ, sets — medium sizing keeps their bluff-catching range in. Don't overbet a wet flop runout."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["river_thin_value", "underfold_exploit"],
+        "explanation": "Passive rec two-street callers don't fold QJ or JJ to river bets. Bet pot-sized or overbet — they'll call."
+      },
+      "C": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["river_thin_value", "underfold_exploit"],
+        "explanation": "Gambly pool calls off with top pair on river regularly. Overbet and extract max vs their under-folding tendency."
+      }
+    },
+    "tags": ["street:river", "pot:srp", "position:ip", "spot:value_sizing", "decision:river_sizing"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Using medium sizing with nutted hands and leaving value on the table", "Being too conservative vs sticky pools that don't fold top pair"],
+      "population_note": "Sticky live pools calling two streets on a connected board signal an inability to fold. Size up with strong hands — the calling frequency doesn't drop enough to justify going small."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_rv02_02",
+    "node_id": "river_02",
+    "version": "1.0.0",
+    "title": "River Sizing vs Sticky Pool — Second Pair, Keep It Small",
+    "prompt": "SRP, IP. Board A♣9♠4♦T♦5♣. Villain checks river. Hero has 9♥8♥ (second pair). What sizing?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "river",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["9h", "8h"],
+      "effective_stack_bb": 90,
+      "board": {
+        "flop": ["Ac", "9s", "4d"],
+        "turn": "Td",
+        "river": "5c"
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "bet", "size_pct_pot": 40 },
+        { "street": "flop", "player": "BB", "action": "call" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "BTN", "action": "check" },
+        { "street": "river", "player": "BB", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "river",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/4-1/3 pot)" },
+      { "key": "RAISE", "label": "Bet Large (~2/3 pot)" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": ["FOLD"],
+      "required_tags": ["river_thin_value"],
+      "explanation": "Second pair on an ace-high board is thin. A small probe at 1/4-1/3 pot targets villain's 4x, 5x, and air holdings. Large sizing only gets called by Ax and better 9x. Keep it small or check — don't spew into a range that beats you."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Competent player's flop-call range includes Ax heavily — second pair is too thin for any bet."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": ["FOLD"],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Passive rec calls with 4x, 5x, worse pairs — small probe at 1/3 pot captures some value. Don't bet large."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": ["CALL"],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Aggro pool calls river with Ax and check-raise bluffs are a concern — check is safer with second pair."
+      }
+    },
+    "tags": ["street:river", "pot:srp", "position:ip", "spot:thin_value_sizing", "decision:river_sizing"],
+    "difficulty": 3,
+    "coaching_context": {
+      "common_mistakes": ["Bet-sizing second pair the same as strong hands", "Going large with thin value and getting called only by better hands"],
+      "population_note": "Sizing discipline is critical for thin river value. Second pair on ace-high boards requires small sizing to be profitable — the calling range for larger bets beats you."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_rv02_03",
+    "node_id": "river_02",
+    "version": "1.0.0",
+    "title": "River Overbet — Nutted Hand vs Capped Range",
+    "prompt": "SRP, IP. Two streets of betting built a $120 pot. Board K♣J♣5♦8♦2♠. Villain checked river after calling turn. Hero has K♠K♦ (top set). Villain's range is capped — no flushes, no straights. Overbet?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "river",
+      "pot_type": "SRP",
+      "players_to_flop": 2,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["Ks", "Kd"],
+      "effective_stack_bb": 80,
+      "board": {
+        "flop": ["Kc", "Jc", "5d"],
+        "turn": "8d",
+        "river": "2s"
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "bet", "size_pct_pot": 50 },
+        { "street": "flop", "player": "BB", "action": "call" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "BTN", "action": "bet", "size_pct_pot": 60 },
+        { "street": "turn", "player": "BB", "action": "call" },
+        { "street": "river", "player": "BB", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "river",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Pot-Sized Bet" },
+      { "key": "RAISE", "label": "Overbet (1.5x-2x pot)" }
+    ],
+    "answer": {
+      "correct": "RAISE",
+      "accepted": ["CALL"],
+      "required_tags": ["river_thin_value", "underfold_exploit"],
+      "explanation": "Hero has top set and villain is range-capped (checked back river, couldn't have turned flush or straight). Villain's range is KJ, JJ, 8x, 5x. Overbet: KJ, JJ cannot fold vs an IP overbet in a live pool. Extract maximum vs their capped sticky range."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["river_thin_value"],
+        "explanation": "Competent player may fold KJ to a 2x overbet — pot-sized bet keeps their marginal holdings in."
+      },
+      "B": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["river_thin_value", "underfold_exploit"],
+        "explanation": "Passive recs call off with KJ, JJ, top pair routinely. Overbet them — their under-folding is the exploit."
+      },
+      "C": {
+        "correct": "RAISE",
+        "accepted": [],
+        "required_tags": ["river_thin_value", "underfold_exploit"],
+        "explanation": "Gambly pool calls large bets with any pair. Overbet with the nuts."
+      }
+    },
+    "tags": ["street:river", "pot:srp", "position:ip", "spot:overbet", "decision:river_overbet"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Using standard sizing when villain is range-capped and sticky", "Fearing that large bets fold out their value hands"],
+      "population_note": "The overbet is unlocked when villain is capped and sticky. Live passive pools cannot fold two pair or overpairs to river overbets — exploit it with your nutted range."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_mw02_01",
+    "node_id": "mw_02",
+    "version": "1.0.0",
+    "title": "Multiway Turn — Overpair on Low Board, Protection Bet or Check?",
+    "prompt": "3-way pot (BTN opened, MP and BB called). Pot $75. Board 7♠4♦2♣9♠ (turn). MP checks, BB checks. Hero (BTN) has A♣A♠. What to do?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "multiway",
+      "players_to_flop": 3,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["Ac", "As"],
+      "effective_stack_bb": 85,
+      "board": {
+        "flop": ["7s", "4d", "2c"],
+        "turn": "9s",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "MP", "action": "call", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "MP", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "bet", "size_pct_pot": 40 },
+        { "street": "flop", "player": "MP", "action": "call" },
+        { "street": "flop", "player": "BB", "action": "fold" },
+        { "street": "turn", "player": "MP", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/4-1/3 pot)" },
+      { "key": "RAISE", "label": "Bet Large (~2/3 pot)" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": ["FOLD"],
+      "required_tags": ["multiway_turn_discipline"],
+      "explanation": "Overpair in what became HU after BB folded — small protection bet is correct. Turn 9♠ adds a flush draw and gives MP potential two-pair with 97. Bet small (1/3 pot) to deny equity and extract thin value; large sizing bloats the pot vs sets and two-pair."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": ["CALL"],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Competent player calls flop with sets, two-pair, draws. Aces face tough reverse implied odds — check and control pot."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Passive MP often floats flop with pairs or draws. Small bet charges them and extracts thin value."
+      },
+      "C": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Gambly MP may raise small bet with two pair — that's information you can use. Bet small, fold to raise."
+      }
+    },
+    "tags": ["street:turn", "pot:multiway", "position:ip", "spot:multiway_barrel", "decision:multiway_sizing"],
+    "difficulty": 3,
+    "coaching_context": {
+      "common_mistakes": ["Betting large with overpairs in multiway pots", "Checking back completely and giving free equity to draws"],
+      "population_note": "Multiway overpairs demand sizing discipline. Small protection bets serve dual purpose: extract value from worse pairs and charge draws. Large bets pot-commit you vs hands that have you crushed."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_mw02_02",
+    "node_id": "mw_02",
+    "version": "1.0.0",
+    "title": "Multiway Turn — TPTK + Gutshot vs MP Donk Bet",
+    "prompt": "3-way pot (BTN/MP/BB). Pot $90. Board J♥9♣6♦5♦ (turn, connected). MP donk-leads $40. BB folds. Hero (BTN) has J♠T♦ (TPTK + gutshot). Call, fold, or raise?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "multiway",
+      "players_to_flop": 3,
+      "hero_position": "BTN",
+      "villain_position": "MP",
+      "hero_hand": ["Js", "Td"],
+      "effective_stack_bb": 82,
+      "board": {
+        "flop": ["Jh", "9c", "6d"],
+        "turn": "5d",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "MP", "action": "call", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "MP", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "bet", "size_pct_pot": 50 },
+        { "street": "flop", "player": "MP", "action": "call" },
+        { "street": "flop", "player": "BB", "action": "call" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "MP", "action": "bet", "size_bb": 8 }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "bet", "size_bb": 8 },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Fold" },
+      { "key": "CALL", "label": "Call" },
+      { "key": "RAISE", "label": "Raise" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": [],
+      "required_tags": ["multiway_turn_discipline"],
+      "explanation": "TPTK + gutshot (8 outs to straight) has too much equity to fold vs a small MP donk. Call and see river. Raising is too thin multiway — MP has a wide donk range but could have 78s, 97s, sets that dominate. Call and realize equity."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Competent donk range includes sets/two-pair and draws — raising TPTK is too loose. Call with equity."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Passive MP donk range is value-heavy (JX, two-pair, draws). TPTK + gutshot has enough equity to call the small size."
+      },
+      "C": {
+        "correct": "CALL",
+        "accepted": ["RAISE"],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Aggro MP may donk wide including bluffs. Call or small raise to define — don't over-commit."
+      }
+    },
+    "tags": ["street:turn", "pot:multiway", "position:ip", "spot:multiway_call", "decision:vs_donk"],
+    "difficulty": 3,
+    "coaching_context": {
+      "common_mistakes": ["Folding TPTK + gutshot to a small multiway donk bet", "Over-raising multiway without the top of your range"],
+      "population_note": "Multiway donk bets are frequently value-heavy in live pools. TPTK + straight draw has too much equity to fold small sizing — call and reassess river."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_mw02_03",
+    "node_id": "mw_02",
+    "version": "1.0.0",
+    "title": "Multiway Turn — Semi-Bluff or Check on Dangerous Board?",
+    "prompt": "3-way pot (BTN/HJ/BB). Pot $65. Board Q♠J♦7♦T♠ (dangerous for aggressor). HJ and BB both check. Hero (BTN) has 8♠9♠ (OESD, no pair). Semi-bluff or check?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "turn",
+      "pot_type": "multiway",
+      "players_to_flop": 3,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["8s", "9s"],
+      "effective_stack_bb": 87,
+      "board": {
+        "flop": ["Qs", "Jd", "7d"],
+        "turn": "Ts",
+        "river": null
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "HJ", "action": "call", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "HJ", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "HJ", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "turn",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Semi-Bluff Small" },
+      { "key": "RAISE", "label": "Semi-Bluff Large" }
+    ],
+    "answer": {
+      "correct": "FOLD",
+      "accepted": [],
+      "required_tags": ["multiway_turn_discipline"],
+      "explanation": "Q-J-7-T is an extremely connected board. Two opponents in multiway shrink fold equity to near zero — live players never fold two pair, sets, or straights. Semi-bluffing an OESD here has no merit. Check back and take the free river."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Competent players check connected boards with strong holdings. Semi-bluffing vs 2 opponents on Q-J-7-T has near-zero fold equity."
+      },
+      "B": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Passive recs call down with any pair or draw. Zero fold equity with OESD vs 2 players — check."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Aggro pool may check-raise semi-bluffs — putting 89s in a terrible spot. Check back."
+      }
+    },
+    "tags": ["street:turn", "pot:multiway", "position:ip", "spot:multiway_give_up", "decision:check_back"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Semi-bluffing draws into multiway pots with highly connected boards", "Confusing HU fold equity logic with multiway realities"],
+      "population_note": "Multiway semi-bluffing rules: fold equity drops sharply with 2+ opponents, especially on connected boards where calling ranges are strong. Take free cards — don't bluff."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_mw03_01",
+    "node_id": "mw_03",
+    "version": "1.0.0",
+    "title": "Multiway River — Second Pair, Check or Thin Value?",
+    "prompt": "3-way pot to river (HJ/CO/BTN). Pot $110. Board A♠T♣5♦3♥2♠. HJ checks, CO checks. Hero (BTN) has T♦9♦ (second pair). Thin value bet or check?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "river",
+      "pot_type": "multiway",
+      "players_to_flop": 3,
+      "hero_position": "BTN",
+      "villain_position": "CO",
+      "hero_hand": ["Td", "9d"],
+      "effective_stack_bb": 78,
+      "board": {
+        "flop": ["As", "Tc", "5d"],
+        "turn": "3h",
+        "river": "2s"
+      },
+      "action_history": [
+        { "street": "preflop", "player": "HJ", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "CO", "action": "call", "size_bb": 3 },
+        { "street": "preflop", "player": "BTN", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "HJ", "action": "bet", "size_pct_pot": 40 },
+        { "street": "flop", "player": "CO", "action": "call" },
+        { "street": "flop", "player": "BTN", "action": "call" },
+        { "street": "turn", "player": "HJ", "action": "check" },
+        { "street": "turn", "player": "CO", "action": "check" },
+        { "street": "turn", "player": "BTN", "action": "check" },
+        { "street": "river", "player": "HJ", "action": "check" },
+        { "street": "river", "player": "CO", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "river",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/4 pot)" },
+      { "key": "RAISE", "label": "Bet Large (~2/3 pot)" }
+    ],
+    "answer": {
+      "correct": "FOLD",
+      "accepted": [],
+      "required_tags": ["multiway_turn_discipline", "river_thin_value"],
+      "explanation": "Second pair on an A-high board in a 3-way pot is far too thin to bet. Both opponents checked two streets — their range still includes Ax, which beats second pair. Check back and take a free showdown. Betting risks being called by better and fold equity is minimal."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline", "river_thin_value"],
+        "explanation": "Multiway river with second pair is a clear check. At least one opponent likely has Ax."
+      },
+      "B": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline", "river_thin_value"],
+        "explanation": "Passive recs check Ax for pot control. Second pair calling range beats hero too often to bet."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline", "river_thin_value"],
+        "explanation": "Gambly players also check strong hands — check back second pair and protect showdown value."
+      }
+    },
+    "tags": ["street:river", "pot:multiway", "position:ip", "spot:multiway_river", "decision:check_back"],
+    "difficulty": 2,
+    "coaching_context": {
+      "common_mistakes": ["Thin-value betting in multiway river pots with marginal hands", "Applying HU thin-value logic to 3-way rivers"],
+      "population_note": "Multiway river thin value thresholds are much higher than HU. Second pair vs two opponents who both checked Ax-heavy boards is a clear check — protect your showdown equity."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_mw03_02",
+    "node_id": "mw_03",
+    "version": "1.0.0",
+    "title": "Multiway River — Top Pair, Small Value Bet in 3-Way",
+    "prompt": "3-way pot to river (BTN/MP/BB). Pot $90. Board K♣7♠2♦4♥J♣ (dry). MP and BB check. Hero (BTN) has K♥Q♦ (TPGK). Bet or check?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "river",
+      "pot_type": "multiway",
+      "players_to_flop": 3,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["Kh", "Qd"],
+      "effective_stack_bb": 82,
+      "board": {
+        "flop": ["Kc", "7s", "2d"],
+        "turn": "4h",
+        "river": "Jc"
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "MP", "action": "call", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "MP", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "bet", "size_pct_pot": 40 },
+        { "street": "flop", "player": "MP", "action": "call" },
+        { "street": "flop", "player": "BB", "action": "call" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "MP", "action": "check" },
+        { "street": "turn", "player": "BTN", "action": "check" },
+        { "street": "river", "player": "BB", "action": "check" },
+        { "street": "river", "player": "MP", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "river",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back" },
+      { "key": "CALL", "label": "Bet Small (~1/4-1/3 pot)" },
+      { "key": "RAISE", "label": "Bet Large (~2/3 pot)" }
+    ],
+    "answer": {
+      "correct": "CALL",
+      "accepted": ["FOLD"],
+      "required_tags": ["multiway_turn_discipline", "river_thin_value"],
+      "explanation": "TPGK in multiway where both opponents checked every street is a small-bet spot. A 1/3-pot bet extracts thin value from Kx-worse, 7x, Jx. Large sizing is wrong — check-raises are more likely 3-way and large bets only get called by hands that beat or tie you."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": ["CALL"],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Competent players check Kx sets and two-pair — TPGK is a marginal value bet in 3-way. Check is safer."
+      },
+      "B": {
+        "correct": "CALL",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline", "river_thin_value"],
+        "explanation": "Passive recs check Kx-worse, 7x, Jx. Small bet extracts from the bottom of their range — don't go large."
+      },
+      "C": {
+        "correct": "CALL",
+        "accepted": ["FOLD"],
+        "required_tags": ["multiway_turn_discipline", "river_thin_value"],
+        "explanation": "Aggro pool checks down medium-strength hands too. Small bet acceptable; check also fine."
+      }
+    },
+    "tags": ["street:river", "pot:multiway", "position:ip", "spot:multiway_river_value", "decision:thin_value"],
+    "difficulty": 3,
+    "coaching_context": {
+      "common_mistakes": ["Checking back TPGK in multiway when the runout is dry and both opponents checked", "Betting large with TPGK in 3-way and getting raised off the best hand"],
+      "population_note": "Multiway TPGK river value requires small sizing discipline. The sweet spot is 1/3 pot — captures calls from worse Kx and pairs while minimizing exposure to check-raises."
+    },
+    "metadata": { "source": "manual" }
+  },
+  {
+    "drill_id": "lc2_mw03_03",
+    "node_id": "mw_03",
+    "version": "1.0.0",
+    "title": "Multiway River — Missed Draw, Bluff or Give Up?",
+    "prompt": "3-way pot to river. Board 9♠8♦4♣3♠7♥. Two opponents remain. Hero has A♠K♠ (flopped nut flush draw, missed; turn gave OESD, missed). Both opponents check. Bluff or check?",
+    "scenario": {
+      "game": "NLHE Cash",
+      "street": "river",
+      "pot_type": "multiway",
+      "players_to_flop": 3,
+      "hero_position": "BTN",
+      "villain_position": "BB",
+      "hero_hand": ["As", "Ks"],
+      "effective_stack_bb": 80,
+      "board": {
+        "flop": ["9s", "8d", "4c"],
+        "turn": "3s",
+        "river": "7h"
+      },
+      "action_history": [
+        { "street": "preflop", "player": "BTN", "action": "open", "size_bb": 3 },
+        { "street": "preflop", "player": "MP", "action": "call", "size_bb": 3 },
+        { "street": "preflop", "player": "BB", "action": "call", "size_bb": 3 },
+        { "street": "flop", "player": "BB", "action": "check" },
+        { "street": "flop", "player": "MP", "action": "check" },
+        { "street": "flop", "player": "BTN", "action": "check" },
+        { "street": "turn", "player": "BB", "action": "check" },
+        { "street": "turn", "player": "MP", "action": "check" },
+        { "street": "turn", "player": "BTN", "action": "check" },
+        { "street": "river", "player": "BB", "action": "check" },
+        { "street": "river", "player": "MP", "action": "check" }
+      ]
+    },
+    "decision_point": {
+      "street": "river",
+      "facing": { "action": "check" },
+      "sizing_buttons_enabled": false
+    },
+    "options": [
+      { "key": "FOLD", "label": "Check Back (give up)" },
+      { "key": "CALL", "label": "Bluff Small" },
+      { "key": "RAISE", "label": "Bluff Large" }
+    ],
+    "answer": {
+      "correct": "FOLD",
+      "accepted": [],
+      "required_tags": ["multiway_turn_discipline", "river_thin_value"],
+      "explanation": "Bluffing into two opponents on a 9-8-4-3-7 connected river is -EV regardless of pool. Both need to fold; live pools almost never fold multiway rivers with any pair. Check back and accept the loss — bluffing multiway with no equity is a pure spew."
+    },
+    "answer_by_pool": {
+      "A": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Competent players check back strong hands in multiway — bluffing two opponents requires both to fold. Near-impossible on 9-8-4-3-7."
+      },
+      "B": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Passive recs call rivers with any pair. Zero fold equity vs two players — don't bluff."
+      },
+      "C": {
+        "correct": "FOLD",
+        "accepted": [],
+        "required_tags": ["multiway_turn_discipline"],
+        "explanation": "Even aggro pools: bluffing two opponents simultaneously on a connected board is nearly impossible. Check."
+      }
+    },
+    "tags": ["street:river", "pot:multiway", "position:ip", "spot:multiway_give_up", "decision:check_back"],
+    "difficulty": 1,
+    "coaching_context": {
+      "common_mistakes": ["Bluffing missed draws into multiway pots on connected boards", "Treating multiway bluffing like a HU opportunity"],
+      "population_note": "The fundamental multiway bluff rule: both opponents need to fold. On connected boards with live pools, this never happens. Take the free showdown — preserve stack discipline."
+    },
+    "metadata": { "source": "manual" }
+  }
+]

--- a/content/nodes/bb/bb_01.json
+++ b/content/nodes/bb/bb_01.json
@@ -1,0 +1,13 @@
+{
+  "node_id": "bb_01",
+  "name": "BB Defend vs BTN Open — Live Thresholds",
+  "version": "1.0.0",
+  "context": {
+    "player_count_flop": 2,
+    "position": "OOP",
+    "street": "preflop",
+    "pot_type": "SRP"
+  },
+  "triggers": ["bb_defend_live", "preflop_3bet"],
+  "defaults": { "population_toggle": "B" }
+}

--- a/content/nodes/bb/bb_02.json
+++ b/content/nodes/bb/bb_02.json
@@ -1,0 +1,13 @@
+{
+  "node_id": "bb_02",
+  "name": "BB vs SB Steal / Limp — Attack or Defend",
+  "version": "1.0.0",
+  "context": {
+    "player_count_flop": 2,
+    "position": "OOP",
+    "street": "preflop",
+    "pot_type": "SRP"
+  },
+  "triggers": ["bb_defend_live", "underfold_exploit"],
+  "defaults": { "population_toggle": "B" }
+}

--- a/content/nodes/exploit/exploit_01.json
+++ b/content/nodes/exploit/exploit_01.json
@@ -1,0 +1,13 @@
+{
+  "node_id": "exploit_01",
+  "name": "Live Pool Exploit Framing — Under-Bluffing / Over-Calling / Under-Raising",
+  "version": "1.0.0",
+  "context": {
+    "player_count_flop": 2,
+    "position": "mixed",
+    "street": "mixed",
+    "pot_type": "SRP"
+  },
+  "triggers": ["live_exploit_framing", "underfold_exploit", "river_thin_value", "iso_raise_live"],
+  "defaults": { "population_toggle": "B" }
+}

--- a/content/nodes/iso/iso_01.json
+++ b/content/nodes/iso/iso_01.json
@@ -1,0 +1,13 @@
+{
+  "node_id": "iso_01",
+  "name": "BTN/CO Iso-Raise vs Live Limpers (Preflop)",
+  "version": "1.0.0",
+  "context": {
+    "player_count_flop": 2,
+    "position": "IP",
+    "street": "preflop",
+    "pot_type": "SRP"
+  },
+  "triggers": ["iso_raise_live", "range_advantage_ip", "underfold_exploit"],
+  "defaults": { "population_toggle": "B" }
+}

--- a/content/nodes/iso/iso_02.json
+++ b/content/nodes/iso/iso_02.json
@@ -1,0 +1,13 @@
+{
+  "node_id": "iso_02",
+  "name": "Iso-Raise Post-Flop: IP Discipline vs Limper",
+  "version": "1.0.0",
+  "context": {
+    "player_count_flop": 2,
+    "position": "IP",
+    "street": "flop",
+    "pot_type": "SRP"
+  },
+  "triggers": ["iso_raise_live", "cbet_dry_flop", "turn_give_up"],
+  "defaults": { "population_toggle": "B" }
+}

--- a/content/nodes/mw/mw_02.json
+++ b/content/nodes/mw/mw_02.json
@@ -1,0 +1,13 @@
+{
+  "node_id": "mw_02",
+  "name": "Multiway Turn Discipline — Barrel or Give Up",
+  "version": "1.0.0",
+  "context": {
+    "player_count_flop": 3,
+    "position": "IP",
+    "street": "turn",
+    "pot_type": "multiway"
+  },
+  "triggers": ["multiway_turn_discipline", "multiway_context", "turn_give_up"],
+  "defaults": { "population_toggle": "B" }
+}

--- a/content/nodes/mw/mw_03.json
+++ b/content/nodes/mw/mw_03.json
@@ -1,0 +1,13 @@
+{
+  "node_id": "mw_03",
+  "name": "Multiway River — Thin Value and Bluff Defense",
+  "version": "1.0.0",
+  "context": {
+    "player_count_flop": 3,
+    "position": "IP",
+    "street": "river",
+    "pot_type": "multiway"
+  },
+  "triggers": ["multiway_turn_discipline", "river_thin_value", "multiway_context"],
+  "defaults": { "population_toggle": "B" }
+}

--- a/content/nodes/river/river_01.json
+++ b/content/nodes/river/river_01.json
@@ -1,0 +1,13 @@
+{
+  "node_id": "river_01",
+  "name": "River Thin Value vs Capped Recreational Ranges",
+  "version": "1.0.0",
+  "context": {
+    "player_count_flop": 2,
+    "position": "IP",
+    "street": "river",
+    "pot_type": "SRP"
+  },
+  "triggers": ["river_thin_value", "merge_vs_passive", "underfold_exploit"],
+  "defaults": { "population_toggle": "B" }
+}

--- a/content/nodes/river/river_02.json
+++ b/content/nodes/river/river_02.json
@@ -1,0 +1,13 @@
+{
+  "node_id": "river_02",
+  "name": "River Sizing vs Sticky Passive Pools",
+  "version": "1.0.0",
+  "context": {
+    "player_count_flop": 2,
+    "position": "IP",
+    "street": "river",
+    "pot_type": "SRP"
+  },
+  "triggers": ["river_thin_value", "thin_value_deep", "merge_vs_passive"],
+  "defaults": { "population_toggle": "B" }
+}

--- a/content/nodes/srp/srp_06.json
+++ b/content/nodes/srp/srp_06.json
@@ -1,0 +1,13 @@
+{
+  "node_id": "srp_06",
+  "name": "SRP Delayed C-Bet IP — Turn Stab After Flop Skip",
+  "version": "1.0.0",
+  "context": {
+    "player_count_flop": 2,
+    "position": "IP",
+    "street": "turn",
+    "pot_type": "SRP"
+  },
+  "triggers": ["delayed_cbet", "range_advantage_ip", "turn_give_up"],
+  "defaults": { "population_toggle": "B" }
+}

--- a/content/nodes/srp/srp_07.json
+++ b/content/nodes/srp/srp_07.json
@@ -1,0 +1,13 @@
+{
+  "node_id": "srp_07",
+  "name": "SRP OOP Turn Stab — Lead After BTN Check-Through",
+  "version": "1.0.0",
+  "context": {
+    "player_count_flop": 2,
+    "position": "OOP",
+    "street": "turn",
+    "pot_type": "SRP"
+  },
+  "triggers": ["delayed_cbet", "probe_bet_turn", "underfold_exploit"],
+  "defaults": { "population_toggle": "B" }
+}

--- a/packages/core/src/__tests__/content-loader.test.ts
+++ b/packages/core/src/__tests__/content-loader.test.ts
@@ -21,12 +21,12 @@ describe("content-loader", () => {
   it("loads nodes from content/nodes idempotently", () => {
     const nodesDir = path.join(CONTENT_DIR, "nodes");
     const count1 = loadNodes(db, nodesDir);
-    expect(count1).toBe(20);
-    expect(getAllNodes(db)).toHaveLength(20);
+    expect(count1).toBe(31);
+    expect(getAllNodes(db)).toHaveLength(31);
 
     const count2 = loadNodes(db, nodesDir);
-    expect(count2).toBe(20);
-    expect(getAllNodes(db)).toHaveLength(20);
+    expect(count2).toBe(31);
+    expect(getAllNodes(db)).toHaveLength(31);
   });
 
   it("loads canonical drills from content/drills idempotently", () => {
@@ -34,13 +34,13 @@ describe("content-loader", () => {
 
     const drillsDir = path.join(CONTENT_DIR, "drills");
     const count1 = loadDrills(db, drillsDir);
-    expect(count1).toBe(60);
-    expect(getAllDrills(db)).toHaveLength(60);
+    expect(count1).toBe(93);
+    expect(getAllDrills(db)).toHaveLength(93);
     expect(CanonicalDrillSchema.parse(JSON.parse(getAllDrills(db)[0].content_json)).drill_id).toBeTruthy();
 
     const count2 = loadDrills(db, drillsDir);
-    expect(count2).toBe(60);
-    expect(getAllDrills(db)).toHaveLength(60);
+    expect(count2).toBe(93);
+    expect(getAllDrills(db)).toHaveLength(93);
   });
 
   it("loads truth-rich exemplar drills with authored history, steps, and pool contrast", () => {
@@ -72,8 +72,8 @@ describe("content-loader", () => {
 
   it("loads all content with loadAllContent", () => {
     const result = loadAllContent(db, CONTENT_DIR);
-    expect(result.nodes).toBe(20);
-    expect(result.drills).toBe(60);
+    expect(result.nodes).toBe(31);
+    expect(result.drills).toBe(93);
   });
 
   it("returns 0 for non-existent directories", () => {

--- a/packages/core/src/concept-graph.ts
+++ b/packages/core/src/concept-graph.ts
@@ -110,6 +110,44 @@ const BASE_CONCEPT_NODES: ConceptNodeDefinition[] = [
     summary: "Adjusting thresholds and incentives when more players see the flop.",
     aliases: ["multiway_context"],
   },
+  // v1.2 — Live Cash Pack 2
+  {
+    key: "iso_raise",
+    label: "Iso-Raising",
+    summary: "Punishing live limpers with isolation raises and playing IP in inflated pots.",
+    aliases: ["iso_raise_live", "concept:iso_raise"],
+  },
+  {
+    key: "bb_defense",
+    label: "BB Defense",
+    summary: "Adjusting BB defending thresholds and 3-bet frequency based on live opponent pool tendencies.",
+    aliases: ["bb_defend_live", "concept:bb_defense"],
+  },
+  {
+    key: "delayed_aggression",
+    label: "Delayed Aggression",
+    summary: "C-betting or probing on later streets after checking back the flop or facing a check-through.",
+    aliases: ["delayed_cbet", "concept:delayed_cbet"],
+  },
+  {
+    key: "thin_value_extraction",
+    label: "Thin Value Extraction",
+    summary: "Betting for value in marginal spots against capped or passive ranges that cannot fold medium-strength hands.",
+    aliases: ["river_thin_value", "concept:thin_value"],
+  },
+  {
+    key: "multiway_late_street",
+    label: "Multiway Late Street",
+    summary: "Managing turn and river decisions in multiway pots — lower bluffing incentives, tighter value thresholds.",
+    aliases: ["multiway_turn_discipline", "concept:multiway_discipline"],
+  },
+  // v1.2 — Exploit Framing
+  {
+    key: "exploit_framing",
+    label: "Live Pool Exploit Framing",
+    summary: "Adjusting decisions based on population tendencies: fold more vs under-bluffing pools, value-bet wider vs over-callers, size up vs under-raising tables.",
+    aliases: ["live_exploit_framing", "concept:exploit_framing"],
+  },
 ];
 
 const BASE_CONCEPT_EDGES: ConceptEdge[] = [
@@ -129,6 +167,21 @@ const BASE_CONCEPT_EDGES: ConceptEdge[] = [
   { from: "river_defense", to: "bluff_catching", type: "related", note: "Many bluff-catching mistakes are a subtype of river defense." },
   { from: "scare_card_pressure", to: "river_defense", type: "related", note: "Scare-card decisions often show up on river defense nodes." },
   { from: "equity_denial", to: "cbetting", type: "related", note: "Equity-denial decisions commonly overlap with c-bet logic." },
+  // v1.2 edges
+  { from: "iso_raise", to: "range_advantage", type: "supports", note: "Iso-raising builds IP range advantage in inflated pots." },
+  { from: "iso_raise", to: "population_pressure", type: "related", note: "Iso-raise frequency and sizing depend heavily on pool tendencies." },
+  { from: "bb_defense", to: "population_pressure", type: "supports", note: "BB defense thresholds are highly pool-dependent in live cash games." },
+  { from: "delayed_aggression", to: "cbetting", type: "related", note: "Delayed c-bets are an extension of post-flop aggression principles." },
+  { from: "delayed_aggression", to: "range_advantage", type: "supports", note: "Delayed stabs exploit IP range advantage when opponent shows weakness." },
+  { from: "thin_value_extraction", to: "value_targeting", type: "supports", note: "Thin value depends on opponent's inability to fold medium-strength hands." },
+  { from: "thin_value_extraction", to: "population_pressure", type: "supports", note: "Thin value opportunities increase against passive, over-calling pools." },
+  { from: "multiway_late_street", to: "multiway_awareness", type: "supports", note: "Late-street multiway discipline builds on flop multiway threshold awareness." },
+  { from: "multiway_late_street", to: "value_targeting", type: "related", note: "Thin value thresholds tighten significantly in multiway late-street spots." },
+  // Exploit framing edges
+  { from: "exploit_framing", to: "population_pressure", type: "supports", note: "Exploit framing is the applied arm of population pressure — converting reads into decisions." },
+  { from: "exploit_framing", to: "value_targeting", type: "supports", note: "Thin value extractions depend on identifying over-calling tendencies." },
+  { from: "exploit_framing", to: "bluff_catching", type: "supports", note: "Bluff-catch width narrows against under-bluffing live pools." },
+  { from: "exploit_framing", to: "iso_raise", type: "related", note: "ISO sizing exploits under-raising passive tables directly." },
 ];
 
 const CONCEPT_SOURCE_TO_KEY = new Map<string, string>();
@@ -167,6 +220,14 @@ const RULE_TAG_TO_CONCEPTS: Record<RuleTag, string[]> = {
   "3bet_pot_cbet": ["cbetting", "3bet_pot_play"],
   preflop_3bet: ["preflop_decision", "range_advantage"],
   turn_give_up: ["turn_aggression", "equity_denial"],
+  // v1.2
+  iso_raise_live: ["iso_raise", "range_advantage", "population_pressure"],
+  bb_defend_live: ["bb_defense", "population_pressure"],
+  delayed_cbet: ["delayed_aggression", "cbetting", "range_advantage"],
+  river_thin_value: ["thin_value_extraction", "value_targeting", "population_pressure"],
+  multiway_turn_discipline: ["multiway_late_street", "multiway_awareness", "turn_defense"],
+  // v1.2 — Exploit Framing
+  live_exploit_framing: ["exploit_framing", "population_pressure", "value_targeting", "bluff_catching"],
 };
 
 export function buildConceptGraph(drills: CanonicalDrill[] = []): ConceptGraph {

--- a/packages/core/src/tags.ts
+++ b/packages/core/src/tags.ts
@@ -1,4 +1,4 @@
-/** All valid rule tags for v1 + v1.1 */
+/** All valid rule tags for v1 + v1.1 + v1.2 (Live Cash Pack 2) */
 export const VALID_TAGS = [
   "paired_top_river",
   "scare_river_ace",
@@ -22,6 +22,14 @@ export const VALID_TAGS = [
   "3bet_pot_cbet",
   "preflop_3bet",
   "turn_give_up",
+  // v1.2 — Live Cash Pack 2
+  "iso_raise_live",
+  "bb_defend_live",
+  "delayed_cbet",
+  "river_thin_value",
+  "multiway_turn_discipline",
+  // v1.2 — Live Cash Pack 2 — Exploit Framing
+  "live_exploit_framing",
 ] as const;
 
 export type RuleTag = (typeof VALID_TAGS)[number];
@@ -55,6 +63,12 @@ export function tagLabel(tag: RuleTag): string {
     "3bet_pot_cbet": "C-bet in 3-bet pot",
     preflop_3bet: "Preflop 3-bet decision",
     turn_give_up: "Turn give-up as aggressor",
+    iso_raise_live: "Iso-raising live limpers",
+    bb_defend_live: "BB defend in live pool",
+    delayed_cbet: "Delayed c-bet / turn stab after flop skip",
+    river_thin_value: "River thin value vs capped ranges",
+    multiway_turn_discipline: "Turn discipline in multiway pots",
+    live_exploit_framing: "Live pool exploit framing — population-adjusted decisions",
   };
   return labels[tag];
 }


### PR DESCRIPTION
- add next live-cash curriculum pack
- deepen iso/limp-punish, BB defend, delayed c-bets, thin value, multiway turn/river, exploit framing
- improve content depth and live-pool specificity