### PR TITLE
feat: add calibration surface adapter

### DIFF
--- a/apps/table-sim/src/lib/calibration-surface.test.ts
+++ b/apps/table-sim/src/lib/calibration-surface.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CalibrationOutcomesBundle } from "./calibration-outcomes";
+import { buildCalibrationSurfaceAdapter, fetchCalibrationSurface } from "./calibration-surface";
+
+function makeBundle(overrides: Partial<CalibrationOutcomesBundle> = {}): CalibrationOutcomesBundle {
+  return {
+    generatedAt: "2026-03-24T16:00:00.000Z",
+    state: "strong_evidence",
+    summary: {
+      headline: "Calibration outcomes include strong evidence.",
+      detail: "2 concepts already have strong evidence.",
+      conceptCount: 2,
+      regressingCount: 1,
+      helpingCount: 1,
+      inconclusiveCount: 0,
+      strongEvidenceCount: 2,
+    },
+    concepts: [
+      {
+        conceptKey: "river_value_thresholds",
+        label: "River Value Thresholds",
+        interventionState: "regressing",
+        evidenceState: "strong_evidence",
+        transferConfirmation: {
+          status: "transfer_regressed",
+          confidence: "high",
+          pressure: "high",
+          evidenceSufficiency: "strong",
+          summary: "Transfer has regressed in recent hands.",
+        },
+        retentionTrend: {
+          latestState: "completed_fail",
+          validationState: "failed",
+          lastResult: "fail",
+          dueCount: 0,
+          overdueCount: 0,
+          summary: "Recent retention validation failed, so the concept is not holding cleanly.",
+        },
+        trustSignals: {
+          trustLevel: "medium",
+          evidenceState: "strong_evidence",
+          decisionStability: "stable",
+          signals: ["2 intervention cycles tracked", "transfer transfer regressed", "retention failed"],
+        },
+        nextStep: {
+          action: "repair_transfer_gap",
+          priority: "high",
+          reason: "Replay and repair the transfer leak before the next session.",
+        },
+        whyThisStillMatters: "Transfer has slipped after earlier progress, so this concept remains trust-critical.",
+      },
+      {
+        conceptKey: "turn_probe_discipline",
+        label: "Turn Probe Discipline",
+        interventionState: "helping",
+        evidenceState: "strong_evidence",
+        transferConfirmation: {
+          status: "transfer_validated",
+          confidence: "high",
+          pressure: "low",
+          evidenceSufficiency: "strong",
+          summary: "Transfer is validated.",
+        },
+        retentionTrend: {
+          latestState: "completed_pass",
+          validationState: "validated",
+          lastResult: "pass",
+          dueCount: 0,
+          overdueCount: 0,
+          summary: "Retention has been validated recently.",
+        },
+        trustSignals: {
+          trustLevel: "high",
+          evidenceState: "strong_evidence",
+          decisionStability: "stable",
+          signals: ["1 intervention cycle tracked", "transfer transfer validated", "retention validated"],
+        },
+        nextStep: {
+          action: "maintain_validated_gain",
+          priority: "medium",
+          reason: "Keep the concept warm with lighter follow-up.",
+        },
+        whyThisStillMatters: "Validated transfer means this concept can be trusted more, but should still be monitored.",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("calibration surface adapter", () => {
+  it("returns an explicit no_calibration state when no bundle is provided", () => {
+    const surface = buildCalibrationSurfaceAdapter(null);
+
+    expect(surface.state).toBe("no_calibration");
+    expect(surface.topConceptSummaries).toEqual([]);
+    expect(surface.highPriorityCount).toBe(0);
+  });
+
+  it("keeps no meaningful history explicit for sparse calibration bundles", () => {
+    const surface = buildCalibrationSurfaceAdapter(makeBundle({
+      state: "no_meaningful_history",
+      summary: {
+        headline: "Calibration outcomes do not yet have meaningful history.",
+        detail: "Outcome evidence is still sparse.",
+        conceptCount: 1,
+        regressingCount: 0,
+        helpingCount: 0,
+        inconclusiveCount: 1,
+        strongEvidenceCount: 0,
+      },
+      concepts: [{
+        conceptKey: "blind_defense",
+        label: "Blind Defense",
+        interventionState: "inconclusive",
+        evidenceState: "no_meaningful_history",
+        retentionTrend: {
+          validationState: "none",
+          dueCount: 0,
+          overdueCount: 0,
+          summary: "Retention evidence is still sparse.",
+        },
+        trustSignals: {
+          trustLevel: "low",
+          evidenceState: "no_meaningful_history",
+          signals: [],
+        },
+        whyThisStillMatters: "The app still lacks enough outcome evidence to clear this concept confidently.",
+      }],
+    }));
+
+    expect(surface.state).toBe("no_meaningful_history");
+    expect(surface.topConceptSummaries[0]?.priority).toBe("medium");
+    expect(surface.topConceptSummaries[0]?.trustLevel).toBe("low");
+  });
+
+  it("surfaces partial evidence bundles cleanly", () => {
+    const surface = buildCalibrationSurfaceAdapter(makeBundle({
+      state: "partial_evidence",
+      summary: {
+        headline: "Calibration outcomes have partial evidence.",
+        detail: "Only partial trust evidence exists so far.",
+        conceptCount: 1,
+        regressingCount: 0,
+        helpingCount: 0,
+        inconclusiveCount: 1,
+        strongEvidenceCount: 0,
+      },
+      concepts: [{
+        conceptKey: "blind_defense",
+        label: "Blind Defense",
+        interventionState: "inconclusive",
+        evidenceState: "partial_evidence",
+        retentionTrend: {
+          validationState: "provisional",
+          dueCount: 1,
+          overdueCount: 0,
+          summary: "Retention evidence exists, but the concept still needs confirmation.",
+        },
+        trustSignals: {
+          trustLevel: "medium",
+          evidenceState: "partial_evidence",
+          decisionStability: "shifting",
+          signals: ["1 intervention cycle tracked"],
+        },
+        whyThisStillMatters: "The concept still needs confirmation from future outcomes.",
+      }],
+    }));
+
+    expect(surface.state).toBe("partial_evidence");
+    expect(surface.highlightedConcept?.priority).toBe("medium");
+    expect(surface.topConceptSummaries[0]?.retentionSummary).toContain("needs confirmation");
+  });
+
+  it("surfaces the highest-priority concept summary first for strong evidence bundles", () => {
+    const surface = buildCalibrationSurfaceAdapter(makeBundle(), 2);
+
+    expect(surface.state).toBe("strong_evidence");
+    expect(surface.highlightedConcept?.conceptKey).toBe("river_value_thresholds");
+    expect(surface.highlightedConcept?.priority).toBe("high");
+    expect(surface.topConceptSummaries[0]?.suggestedAction?.label).toBe("Repair Transfer Gap");
+    expect(surface.topConceptSummaries[0]?.destination).toBe("/app/concepts/river_value_thresholds");
+    expect(surface.highPriorityCount).toBe(1);
+  });
+
+  it("fetches calibration outcomes and shapes them without duplicating route parsing", async () => {
+    const bundle = makeBundle({
+      concepts: [makeBundle().concepts[0]!],
+      summary: {
+        ...makeBundle().summary,
+        conceptCount: 1,
+      },
+    });
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify(bundle), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+    ) as unknown as typeof fetch;
+
+    const surface = await fetchCalibrationSurface({ limit: 5, topLimit: 1 }, fetchImpl);
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "/api/calibration-outcomes?limit=5",
+      { cache: "no-store" },
+    );
+    expect(surface.topConceptSummaries).toHaveLength(1);
+    expect(surface.highlightedConcept?.conceptKey).toBe("river_value_thresholds");
+  });
+});

--- a/apps/table-sim/src/lib/calibration-surface.ts
+++ b/apps/table-sim/src/lib/calibration-surface.ts
@@ -1,0 +1,129 @@
+import type {
+  CalibrationOutcomeEntry,
+  CalibrationOutcomesBundle,
+  CalibrationOutcomeEvidenceState,
+  CalibrationTrustLevel,
+} from "./calibration-outcomes";
+
+export type CalibrationSurfaceState = "no_calibration" | CalibrationOutcomeEvidenceState;
+export type CalibrationSurfacePriority = "high" | "medium" | "low";
+
+export interface CalibrationSurfaceConceptSummary {
+  conceptKey: string;
+  label: string;
+  priority: CalibrationSurfacePriority;
+  interventionState: CalibrationOutcomeEntry["interventionState"];
+  evidenceState: CalibrationOutcomeEntry["evidenceState"];
+  trustLevel: CalibrationTrustLevel;
+  whyThisStillMatters: string;
+  transferSummary?: string;
+  retentionSummary: string;
+  suggestedAction?: {
+    label: string;
+    detail: string;
+  };
+  destination: string;
+}
+
+export interface CalibrationSurfaceAdapter {
+  state: CalibrationSurfaceState;
+  headline: string;
+  detail: string;
+  generatedAt?: string;
+  topConceptSummaries: CalibrationSurfaceConceptSummary[];
+  highlightedConcept?: CalibrationSurfaceConceptSummary;
+  highPriorityCount: number;
+}
+
+export async function fetchCalibrationSurface(
+  options: {
+    limit?: number;
+    topLimit?: number;
+  } = {},
+  fetchImpl: typeof fetch = fetch,
+): Promise<CalibrationSurfaceAdapter> {
+  const params = new URLSearchParams();
+  if (typeof options.limit === "number" && Number.isFinite(options.limit) && options.limit > 0) {
+    params.set("limit", String(options.limit));
+  }
+
+  const response = await fetchImpl(
+    `/api/calibration-outcomes${params.size > 0 ? `?${params.toString()}` : ""}`,
+    { cache: "no-store" } as RequestInit,
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to load calibration outcomes");
+  }
+
+  return buildCalibrationSurfaceAdapter(await response.json() as CalibrationOutcomesBundle, options.topLimit);
+}
+
+export function buildCalibrationSurfaceAdapter(
+  bundle?: CalibrationOutcomesBundle | null,
+  topLimit = 3,
+): CalibrationSurfaceAdapter {
+  if (!bundle) {
+    return {
+      state: "no_calibration",
+      headline: "Calibration outcomes are not loaded yet.",
+      detail: "Load calibration outcomes before shaping trust summaries for concept, daily-plan, or dashboard surfaces.",
+      topConceptSummaries: [],
+      highPriorityCount: 0,
+    };
+  }
+
+  const topConceptSummaries = bundle.concepts
+    .slice(0, Math.max(0, topLimit))
+    .map((concept) => buildConceptSummary(concept));
+  const highPriorityCount = topConceptSummaries.filter((concept) => concept.priority === "high").length;
+
+  return {
+    state: bundle.state,
+    headline: bundle.summary.headline,
+    detail: bundle.summary.detail,
+    generatedAt: bundle.generatedAt,
+    topConceptSummaries,
+    highlightedConcept: topConceptSummaries[0],
+    highPriorityCount,
+  };
+}
+
+function buildConceptSummary(concept: CalibrationOutcomeEntry): CalibrationSurfaceConceptSummary {
+  return {
+    conceptKey: concept.conceptKey,
+    label: concept.label,
+    priority: derivePriority(concept),
+    interventionState: concept.interventionState,
+    evidenceState: concept.evidenceState,
+    trustLevel: concept.trustSignals.trustLevel,
+    whyThisStillMatters: concept.whyThisStillMatters,
+    transferSummary: concept.transferConfirmation?.summary,
+    retentionSummary: concept.retentionTrend.summary,
+    suggestedAction: concept.nextStep
+      ? {
+          label: formatActionLabel(concept.nextStep.action),
+          detail: concept.nextStep.reason,
+        }
+      : undefined,
+    destination: `/app/concepts/${encodeURIComponent(concept.conceptKey)}`,
+  };
+}
+
+function derivePriority(concept: CalibrationOutcomeEntry): CalibrationSurfacePriority {
+  if (concept.interventionState === "regressing") {
+    return "high";
+  }
+  if (concept.evidenceState === "strong_evidence" || concept.interventionState === "inconclusive") {
+    return "medium";
+  }
+  return "low";
+}
+
+function formatActionLabel(action: string): string {
+  return action
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(" ");
+}


### PR DESCRIPTION
- add reusable calibration surface adapter
- expose top concept summaries and sparse states
- keep calibration consumption thin and reusable for future surfaces