### PR TITLE
feat: consume calibration surface in concept detail and daily plan

### DIFF
--- a/apps/table-sim/src/components/concepts/ConceptCaseScreen.render.test.tsx
+++ b/apps/table-sim/src/components/concepts/ConceptCaseScreen.render.test.tsx
@@ -5,6 +5,7 @@ import { ConceptCaseScreen } from "./ConceptCaseScreen";
 import type { ConceptCaseResponse } from "@/lib/concept-case";
 import type { EngineReplaySummary } from "@/lib/input-snapshots";
 import type { ConceptTransferEvaluation } from "@poker-coach/core/browser";
+import type { CalibrationSurfaceAdapter } from "@/lib/calibration-surface";
 
 function makeReplaySummary(): EngineReplaySummary {
   return {
@@ -228,6 +229,39 @@ function makeConceptCaseResponse(): ConceptCaseResponse {
   };
 }
 
+function makeCalibrationSurface(
+  overrides: Partial<CalibrationSurfaceAdapter> = {},
+): CalibrationSurfaceAdapter {
+  return {
+    state: "strong_evidence",
+    headline: "Calibration outcomes include strong evidence.",
+    detail: "Trust signals are now stable enough to summarize.",
+    generatedAt: "2026-03-25T01:00:00.000Z",
+    conceptSummaries: [
+      {
+        conceptKey: "river_bluff_catching",
+        label: "River Bluff Catching",
+        priority: "high",
+        interventionState: "regressing",
+        evidenceState: "strong_evidence",
+        trustLevel: "medium",
+        whyThisStillMatters: "Transfer has slipped after earlier progress, so this concept remains trust-critical.",
+        transferSummary: "Transfer has regressed in recent hands.",
+        retentionSummary: "Recent retention validation failed, so the concept is not holding cleanly.",
+        suggestedAction: {
+          label: "Repair Transfer Gap",
+          detail: "Replay and repair the transfer leak before the next session.",
+        },
+        destination: "/app/concepts/river_bluff_catching",
+      },
+    ],
+    topConceptSummaries: [],
+    highlightedConcept: undefined,
+    highPriorityCount: 1,
+    ...overrides,
+  };
+}
+
 describe("ConceptCaseScreen", () => {
   it("renders canonical concept-case data without re-deriving explanation text", () => {
     const html = renderToStaticMarkup(<ConceptCaseScreen state={{ loading: false, data: makeConceptCaseResponse() }} />);
@@ -332,6 +366,48 @@ describe("ConceptCaseScreen", () => {
 
     expect(html).toContain("Decision Audit");
     expect(html).toContain("No intervention decision snapshots are stored yet");
+  });
+
+  it("renders concept-specific calibration trust support when available", () => {
+    const calibration = makeCalibrationSurface();
+    const html = renderToStaticMarkup(
+      <ConceptCaseScreen
+        state={{
+          loading: false,
+          data: makeConceptCaseResponse(),
+          calibration,
+          conceptCalibration: calibration.conceptSummaries[0],
+        }}
+      />
+    );
+
+    expect(html).toContain("Calibration Trust");
+    expect(html).toContain("River Bluff Catching calibration");
+    expect(html).toContain("Transfer has regressed in recent hands.");
+  });
+
+  it("renders sparse calibration copy when only bundle-level calibration is available", () => {
+    const html = renderToStaticMarkup(
+      <ConceptCaseScreen
+        state={{
+          loading: false,
+          data: makeConceptCaseResponse(),
+          calibration: makeCalibrationSurface({
+            state: "no_meaningful_history",
+            headline: "Calibration outcomes do not yet have meaningful history.",
+            detail: "The adapter did not find enough persisted outcome history to make strong trust claims yet.",
+            conceptSummaries: [],
+            topConceptSummaries: [],
+            highlightedConcept: undefined,
+            highPriorityCount: 0,
+          }),
+          conceptCalibration: null,
+        }}
+      />
+    );
+
+    expect(html).toContain("Calibration outcomes do not yet have meaningful history.");
+    expect(html).toContain("make strong trust claims yet");
   });
 
   it("renders a loading state cleanly", () => {

--- a/apps/table-sim/src/components/concepts/ConceptCaseScreen.tsx
+++ b/apps/table-sim/src/components/concepts/ConceptCaseScreen.tsx
@@ -7,11 +7,17 @@ import type { ConceptTransferEvaluation } from "@poker-coach/core/browser";
 import type { TransferAuditSummary } from "@/lib/transfer-audit";
 import type { RetentionSummary } from "@/lib/retention-scheduling";
 import type { InterventionDecisionAuditSummary } from "@/lib/intervention-decision-audit";
+import type {
+  CalibrationSurfaceAdapter,
+  CalibrationSurfaceConceptSummary,
+} from "@/lib/calibration-surface";
 
 export interface ConceptCaseScreenState {
   loading: boolean;
   error?: string | null;
   data?: ConceptCaseResponse | null;
+  calibration?: CalibrationSurfaceAdapter | null;
+  conceptCalibration?: CalibrationSurfaceConceptSummary | null;
 }
 
 export function ConceptCaseScreen({ state }: { state: ConceptCaseScreenState }) {
@@ -53,6 +59,10 @@ export function ConceptCaseScreen({ state }: { state: ConceptCaseScreenState }) 
     <ConceptPageFrame>
       <div className="space-y-6">
         <ConceptCaseHeader data={state.data} />
+        <ConceptCalibrationPanel
+          calibration={state.calibration}
+          conceptCalibration={state.conceptCalibration}
+        />
 
         <div className="grid gap-5 xl:grid-cols-[minmax(0,1.02fr)_minmax(320px,0.98fr)]">
           <ConceptStatusCard data={state.data} />
@@ -135,6 +145,54 @@ export function ConceptCaseScreen({ state }: { state: ConceptCaseScreenState }) 
         </section>
       </div>
     </ConceptPageFrame>
+  );
+}
+
+function ConceptCalibrationPanel({
+  calibration,
+  conceptCalibration,
+}: {
+  calibration?: CalibrationSurfaceAdapter | null;
+  conceptCalibration?: CalibrationSurfaceConceptSummary | null;
+}) {
+  if (!calibration || calibration.state === "no_calibration") {
+    return null;
+  }
+
+  const summary = conceptCalibration ?? calibration.highlightedConcept;
+  const title = conceptCalibration
+    ? `${conceptCalibration.label} calibration`
+    : "Calibration summary";
+  const tone = summary?.priority === "high"
+    ? "warning"
+    : calibration.state === "strong_evidence"
+      ? "good"
+      : "neutral";
+
+  return (
+    <ConceptPanel tone={tone} title={title} eyebrow="Calibration Trust">
+      <div className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          <HeaderChip label={calibration.state.replace(/_/g, " ")} />
+          {summary && <HeaderChip label={summary.interventionState.replace(/_/g, " ")} subtle />}
+          {summary && <HeaderChip label={`${summary.trustLevel} trust`} subtle />}
+          {summary && <HeaderChip label={`${summary.priority} priority`} subtle />}
+        </div>
+        <InfoBlock title="Calibration read" detail={summary?.whyThisStillMatters ?? calibration.detail} />
+        {summary && (
+          <div className="grid gap-3 md:grid-cols-2">
+            <HistoryStat title="Retention trend" detail={summary.retentionSummary} />
+            <HistoryStat title="Transfer confirmation" detail={summary.transferSummary ?? "No transfer confirmation summary is attached yet."} />
+          </div>
+        )}
+        {!summary && (
+          <div className="rounded-[22px] border border-white/8 bg-black/20 p-4">
+            <p className="text-sm leading-6 text-slate-200">{calibration.headline}</p>
+            <p className="mt-2 text-sm leading-6 text-slate-300">{calibration.detail}</p>
+          </div>
+        )}
+      </div>
+    </ConceptPanel>
   );
 }
 

--- a/apps/table-sim/src/components/concepts/ConceptCaseView.tsx
+++ b/apps/table-sim/src/components/concepts/ConceptCaseView.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { ConceptCaseScreen, type ConceptCaseScreenState } from "@/components/concepts/ConceptCaseScreen";
 import type { ConceptCaseResponse } from "@/lib/concept-case";
+import { fetchCalibrationSurface, findCalibrationSurfaceConcept } from "@/lib/calibration-surface";
 
 export function ConceptCaseView({ conceptId }: { conceptId: string }) {
   const [state, setState] = useState<ConceptCaseScreenState>({ loading: true });
@@ -13,10 +14,16 @@ export function ConceptCaseView({ conceptId }: { conceptId: string }) {
     async function loadConceptCase() {
       setState({ loading: true });
       try {
-        const response = await fetch(`/api/concept-case/${encodeURIComponent(conceptId)}`, { cache: "no-store" });
+        const [response, calibrationSurface] = await Promise.all([
+          fetch(`/api/concept-case/${encodeURIComponent(conceptId)}`, { cache: "no-store" }),
+          fetchCalibrationSurface({ limit: 12, topLimit: 4 }).catch((error) => {
+            console.error("Failed to load calibration surface:", error);
+            return null;
+          }),
+        ]);
         if (response.status === 404) {
           if (!cancelled) {
-            setState({ loading: false, data: null });
+            setState({ loading: false, data: null, calibration: calibrationSurface });
           }
           return;
         }
@@ -25,7 +32,12 @@ export function ConceptCaseView({ conceptId }: { conceptId: string }) {
         }
         const data = (await response.json()) as ConceptCaseResponse;
         if (!cancelled) {
-          setState({ loading: false, data });
+          setState({
+            loading: false,
+            data,
+            calibration: calibrationSurface,
+            conceptCalibration: findCalibrationSurfaceConcept(calibrationSurface, data.conceptKey),
+          });
         }
       } catch (error) {
         console.error("Failed to load concept case:", error);

--- a/apps/table-sim/src/components/daily/DailyStudyPlan.calibration.render.test.tsx
+++ b/apps/table-sim/src/components/daily/DailyStudyPlan.calibration.render.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { CalibrationSummaryPanel } from "./DailyStudyPlan";
+import type { CalibrationSurfaceAdapter } from "@/lib/calibration-surface";
+
+function makeCalibrationSurface(
+  overrides: Partial<CalibrationSurfaceAdapter> = {},
+): CalibrationSurfaceAdapter {
+  return {
+    state: "strong_evidence",
+    headline: "Calibration outcomes include strong evidence.",
+    detail: "Strong trust evidence is available.",
+    generatedAt: "2026-03-25T01:00:00.000Z",
+    conceptSummaries: [
+      {
+        conceptKey: "river_value_thresholds",
+        label: "River Value Thresholds",
+        priority: "high",
+        interventionState: "regressing",
+        evidenceState: "strong_evidence",
+        trustLevel: "medium",
+        whyThisStillMatters: "Transfer has slipped after earlier progress, so this concept remains trust-critical.",
+        transferSummary: "Transfer has regressed in recent hands.",
+        retentionSummary: "Recent retention validation failed, so the concept is not holding cleanly.",
+        suggestedAction: {
+          label: "Repair Transfer Gap",
+          detail: "Replay and repair the transfer leak before the next session.",
+        },
+        destination: "/app/concepts/river_value_thresholds",
+      },
+    ],
+    topConceptSummaries: [],
+    highlightedConcept: undefined,
+    highPriorityCount: 1,
+    ...overrides,
+  };
+}
+
+describe("CalibrationSummaryPanel", () => {
+  it("renders highlighted calibration support when strong evidence is available", () => {
+    const calibration = makeCalibrationSurface({
+      topConceptSummaries: [makeCalibrationSurface().conceptSummaries[0]!],
+      highlightedConcept: makeCalibrationSurface().conceptSummaries[0],
+    });
+    const html = renderToStaticMarkup(
+      <CalibrationSummaryPanel loading={false} calibration={calibration} />
+    );
+
+    expect(html).toContain("Calibration Summary");
+    expect(html).toContain("Calibration outcomes include strong evidence.");
+    expect(html).toContain("River Value Thresholds");
+    expect(html).toContain("Replay and repair the transfer leak before the next session.");
+  });
+
+  it("renders sparse calibration messaging cleanly", () => {
+    const html = renderToStaticMarkup(
+      <CalibrationSummaryPanel
+        loading={false}
+        calibration={makeCalibrationSurface({
+          state: "no_meaningful_history",
+          headline: "Calibration outcomes do not yet have meaningful history.",
+          detail: "Load more outcome evidence before making strong trust claims.",
+          conceptSummaries: [],
+          topConceptSummaries: [],
+          highlightedConcept: undefined,
+          highPriorityCount: 0,
+        })}
+      />
+    );
+
+    expect(html).toContain("Calibration outcomes do not yet have meaningful history.");
+    expect(html).toContain("Load more outcome evidence");
+  });
+});

--- a/apps/table-sim/src/components/daily/DailyStudyPlan.tsx
+++ b/apps/table-sim/src/components/daily/DailyStudyPlan.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import type {
@@ -9,9 +10,12 @@ import type {
   DailyStudyPlan,
   DailyStudyPlanBundle,
 } from "@/lib/daily-study-plan";
+import type { CalibrationSurfaceAdapter } from "@/lib/calibration-surface";
+import { fetchCalibrationSurface } from "@/lib/calibration-surface";
 
 export function DailyStudyPlan() {
   const [bundle, setBundle] = useState<DailyStudyPlanBundle | null>(null);
+  const [calibration, setCalibration] = useState<CalibrationSurfaceAdapter | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedLength, setSelectedLength] = useState<DailySessionLength>(45);
   // v4: lightweight in-session completion tracking (not persisted)
@@ -23,12 +27,28 @@ export function DailyStudyPlan() {
     async function load() {
       setLoading(true);
       try {
-        const response = await fetch("/api/daily-study-plan", { cache: "no-store" });
-        if (!response.ok) throw new Error("Failed to load daily study plan");
-        const data = (await response.json()) as DailyStudyPlanBundle;
+        const [planResult, calibrationResult] = await Promise.allSettled([
+          fetch("/api/daily-study-plan", { cache: "no-store" }),
+          fetchCalibrationSurface({ limit: 12, topLimit: 1 }),
+        ]);
+
+        if (planResult.status !== "fulfilled") {
+          throw new Error("Failed to load daily study plan");
+        }
+        if (!planResult.value.ok) {
+          throw new Error("Failed to load daily study plan");
+        }
+
+        const data = (await planResult.value.json()) as DailyStudyPlanBundle;
         if (!cancelled) {
           setBundle(data);
           setSelectedLength(data.defaultSessionLength);
+          if (calibrationResult.status === "fulfilled") {
+            setCalibration(calibrationResult.value);
+          } else {
+            console.error("Failed to load calibration surface:", calibrationResult.reason);
+            setCalibration(null);
+          }
         }
       } catch (error) {
         console.error("Failed to load daily study plan:", error);
@@ -82,6 +102,7 @@ export function DailyStudyPlan() {
             />
             <MainFocusCard loading={loading} plan={plan} />
             <PlanSummarySection loading={loading} plan={plan} bundle={bundle} />
+            <CalibrationSummaryPanel loading={loading} calibration={calibration} />
             <BlockList
               loading={loading}
               plan={plan}
@@ -93,6 +114,59 @@ export function DailyStudyPlan() {
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+export function CalibrationSummaryPanel({
+  loading,
+  calibration,
+}: {
+  loading: boolean;
+  calibration: CalibrationSurfaceAdapter | null;
+}) {
+  if (loading) {
+    return <div className="h-24 animate-pulse rounded-xl border border-white/10 bg-white/5" />;
+  }
+
+  if (!calibration || calibration.state === "no_calibration") {
+    return null;
+  }
+
+  const summary = calibration.highlightedConcept;
+  const toneClass = calibration.state === "strong_evidence"
+    ? "border-emerald-500/20 bg-emerald-950/20"
+    : calibration.state === "partial_evidence"
+      ? "border-amber-500/20 bg-amber-950/20"
+      : "border-white/10 bg-white/[0.03]";
+
+  return (
+    <div className={`rounded-xl border px-5 py-4 ${toneClass}`}>
+      <p className="text-xs font-semibold uppercase tracking-widest text-white/40">
+        Calibration Summary
+      </p>
+      <p className="mt-2 text-sm font-medium text-white">{calibration.headline}</p>
+      <p className="mt-1 text-sm text-white/60">{summary?.whyThisStillMatters ?? calibration.detail}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <span className="rounded bg-white/10 px-2 py-0.5 text-xs font-medium text-white/60">
+          {calibration.state.replace(/_/g, " ")}
+        </span>
+        {summary && (
+          <span className="rounded bg-white/10 px-2 py-0.5 text-xs font-medium text-white/60">
+            {summary.label}
+          </span>
+        )}
+        {summary && (
+          <span className="rounded bg-white/10 px-2 py-0.5 text-xs font-medium text-white/60">
+            {summary.interventionState.replace(/_/g, " ")}
+          </span>
+        )}
+      </div>
+      {summary && (
+        <p className="mt-3 text-xs text-white/40">
+          Next move: {summary.suggestedAction?.detail ?? summary.retentionSummary}
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/table-sim/src/lib/calibration-surface.test.ts
+++ b/apps/table-sim/src/lib/calibration-surface.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CalibrationOutcomesBundle } from "./calibration-outcomes";
-import { buildCalibrationSurfaceAdapter, fetchCalibrationSurface } from "./calibration-surface";
+import {
+  buildCalibrationSurfaceAdapter,
+  fetchCalibrationSurface,
+  findCalibrationSurfaceConcept,
+} from "./calibration-surface";
 
 function makeBundle(overrides: Partial<CalibrationOutcomesBundle> = {}): CalibrationOutcomesBundle {
   return {
@@ -92,6 +96,7 @@ describe("calibration surface adapter", () => {
     const surface = buildCalibrationSurfaceAdapter(null);
 
     expect(surface.state).toBe("no_calibration");
+    expect(surface.conceptSummaries).toEqual([]);
     expect(surface.topConceptSummaries).toEqual([]);
     expect(surface.highPriorityCount).toBe(0);
   });
@@ -129,7 +134,6 @@ describe("calibration surface adapter", () => {
     }));
 
     expect(surface.state).toBe("no_meaningful_history");
-    expect(surface.topConceptSummaries[0]?.priority).toBe("medium");
     expect(surface.topConceptSummaries[0]?.trustLevel).toBe("low");
   });
 
@@ -180,6 +184,7 @@ describe("calibration surface adapter", () => {
     expect(surface.topConceptSummaries[0]?.suggestedAction?.label).toBe("Repair Transfer Gap");
     expect(surface.topConceptSummaries[0]?.destination).toBe("/app/concepts/river_value_thresholds");
     expect(surface.highPriorityCount).toBe(1);
+    expect(findCalibrationSurfaceConcept(surface, "turn_probe_discipline")?.label).toBe("Turn Probe Discipline");
   });
 
   it("fetches calibration outcomes and shapes them without duplicating route parsing", async () => {

--- a/apps/table-sim/src/lib/calibration-surface.ts
+++ b/apps/table-sim/src/lib/calibration-surface.ts
@@ -30,6 +30,7 @@ export interface CalibrationSurfaceAdapter {
   headline: string;
   detail: string;
   generatedAt?: string;
+  conceptSummaries: CalibrationSurfaceConceptSummary[];
   topConceptSummaries: CalibrationSurfaceConceptSummary[];
   highlightedConcept?: CalibrationSurfaceConceptSummary;
   highPriorityCount: number;
@@ -68,25 +69,35 @@ export function buildCalibrationSurfaceAdapter(
       state: "no_calibration",
       headline: "Calibration outcomes are not loaded yet.",
       detail: "Load calibration outcomes before shaping trust summaries for concept, daily-plan, or dashboard surfaces.",
+      conceptSummaries: [],
       topConceptSummaries: [],
       highPriorityCount: 0,
     };
   }
 
-  const topConceptSummaries = bundle.concepts
-    .slice(0, Math.max(0, topLimit))
-    .map((concept) => buildConceptSummary(concept));
-  const highPriorityCount = topConceptSummaries.filter((concept) => concept.priority === "high").length;
+  const conceptSummaries = bundle.concepts.map((concept) => buildConceptSummary(concept));
+  const topConceptSummaries = conceptSummaries.slice(0, Math.max(0, topLimit));
 
   return {
     state: bundle.state,
     headline: bundle.summary.headline,
     detail: bundle.summary.detail,
     generatedAt: bundle.generatedAt,
+    conceptSummaries,
     topConceptSummaries,
     highlightedConcept: topConceptSummaries[0],
-    highPriorityCount,
+    highPriorityCount: conceptSummaries.filter((concept) => concept.priority === "high").length,
   };
+}
+
+export function findCalibrationSurfaceConcept(
+  surface: CalibrationSurfaceAdapter | null | undefined,
+  conceptKey: string | null | undefined,
+): CalibrationSurfaceConceptSummary | undefined {
+  if (!surface || !conceptKey) {
+    return undefined;
+  }
+  return surface.conceptSummaries.find((concept) => concept.conceptKey === conceptKey);
 }
 
 function buildConceptSummary(concept: CalibrationOutcomeEntry): CalibrationSurfaceConceptSummary {


### PR DESCRIPTION
## Summary
- consume calibration surface adapter in Daily Study Plan
- consume calibration surface adapter in Concept Detail
- add render coverage for strong and sparse calibration states

## Verification
- pnpm exec tsc --noEmit
- pnpm test
- pnpm build:web

🤖 Generated with [Claude Code](https://claude.com/claude-code)