### PR TITLE
feat: Curriculum Assignment Quality v1 — scoring, variety control, signal enrichment

### DIFF
--- a/apps/table-sim/src/app/api/daily-study-plan/route.ts
+++ b/apps/table-sim/src/app/api/daily-study-plan/route.ts
@@ -8,6 +8,9 @@ import { buildTableSimPlayerIntelligence } from "../../../lib/player-intelligenc
 import { buildPatternAttemptSignals, hydratePersistedStudyAttempts } from "../../../lib/intervention-support";
 import { buildDailyStudyPlanBundle } from "../../../lib/daily-study-plan";
 import { buildPersistedRealHandInterventionBridgeBundle } from "../../../lib/real-hand-bridge";
+import { buildConceptTransferEvaluationMap } from "../../../lib/transfer-evaluation";
+import { buildCalibrationSurfaceAdapter } from "../../../lib/calibration-surface";
+import { buildPersistedCalibrationOutcomesBundle } from "../../../lib/calibration-outcomes";
 
 const ACTIVE_INTERVENTION_STATUSES = new Set(["assigned", "in_progress", "stabilizing"]);
 
@@ -63,6 +66,30 @@ export async function GET() {
       .filter((s) => s.status === "due")
       .map((s) => s.concept_key);
 
+    // v5: build transfer evaluation map for concept assignment scoring
+    const transferEvaluationMap = buildConceptTransferEvaluationMap({
+      playerIntelligence,
+      diagnosisHistory,
+      interventionHistory,
+      realPlaySignals,
+      retentionSchedules,
+      now,
+    });
+
+    // v5: build calibration surface for concept assignment scoring
+    const calibrationBundle = buildPersistedCalibrationOutcomesBundle({
+      drills,
+      attempts,
+      srs,
+      importedHands,
+      diagnoses,
+      interventions,
+      retentionSchedules,
+      activePool,
+      now,
+    });
+    const calibrationSurface = buildCalibrationSurfaceAdapter(calibrationBundle);
+
     // v3: build real-hand bridge bundle when imported hands are present
     const bridgeBundle =
       importedHands.length > 0
@@ -89,6 +116,8 @@ export async function GET() {
       activeInterventionConceptLabel: activeInterventionConcept?.label ?? null,
       now,
       bridgeBundle,
+      transferEvaluationMap,
+      calibrationSurface,
     });
 
     return NextResponse.json(bundle);

--- a/apps/table-sim/src/lib/daily-study-plan.test.ts
+++ b/apps/table-sim/src/lib/daily-study-plan.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { PlayerIntelligenceSnapshot } from "@poker-coach/core/browser";
+import type { ConceptTransferEvaluation, PlayerIntelligenceSnapshot } from "@poker-coach/core/browser";
 import {
   buildDailyStudyPlanBundle,
   DAILY_SESSION_LENGTHS,
   type DailyStudyPlanInput,
 } from "./daily-study-plan";
+import type { CalibrationSurfaceAdapter, CalibrationSurfaceConceptSummary } from "./calibration-surface";
 
 function makeIntelligence(
   overrides: Partial<PlayerIntelligenceSnapshot> = {},
@@ -1355,5 +1356,177 @@ describe("buildDailyStudyPlanBundle — v4: improved no_history / sparse_history
     );
     const block = result.plan20.blocks.find((b) => b.kind === "focus_concept");
     expect(block?.reason).toContain("sharpens");
+  });
+});
+
+// ─── v5: assignment quality helpers ──────────────────────────────────────────
+
+function makeTransferMap(
+  pressureByKey: Record<string, ConceptTransferEvaluation["pressure"]>,
+): Map<string, ConceptTransferEvaluation> {
+  const map = new Map<string, ConceptTransferEvaluation>();
+  for (const [conceptKey, pressure] of Object.entries(pressureByKey)) {
+    map.set(conceptKey, {
+      conceptKey,
+      label: conceptKey,
+      status: "no_real_play_evidence",
+      confidence: "low",
+      evidenceSufficiency: "none",
+      pressure,
+      supportingEvidence: [],
+      riskFlags: [],
+      summary: "",
+      coachExplanation: "",
+      realPlayEvidence: { occurrences: 0, reviewSpotCount: 0 },
+    });
+  }
+  return map;
+}
+
+function makeCalibrationSurface(
+  priorityByKey: Record<string, CalibrationSurfaceConceptSummary["priority"]>,
+): CalibrationSurfaceAdapter {
+  const conceptSummaries: CalibrationSurfaceConceptSummary[] = Object.entries(priorityByKey).map(
+    ([conceptKey, priority]) => ({
+      conceptKey,
+      label: conceptKey,
+      priority,
+      interventionState: "helping" as const,
+      evidenceState: "partial_evidence" as const,
+      trustLevel: "medium" as const,
+      whyThisStillMatters: `${conceptKey} calibration still matters`,
+      retentionSummary: "stable",
+      destination: `/app/concepts/${conceptKey}`,
+    }),
+  );
+  return {
+    state: "partial_evidence",
+    headline: "test",
+    detail: "test",
+    conceptSummaries,
+    topConceptSummaries: conceptSummaries.slice(0, 3),
+    highPriorityCount: conceptSummaries.filter((c) => c.priority === "high").length,
+  };
+}
+
+describe("buildDailyStudyPlanBundle — v5: assignment quality", () => {
+  // Baseline: no v5 fields → same behaviour as before (concept_0 is primary)
+  it("without v5 fields, primary block uses top recommendation unchanged", () => {
+    const result = buildDailyStudyPlanBundle(
+      makeInput({ totalAttempts: 30, playerIntelligence: makeReadyIntelligence() }),
+    );
+    const focusBlock = result.plan45.blocks.find((b) => b.kind === "focus_concept");
+    expect(focusBlock?.conceptKey).toBe("concept_0");
+  });
+
+  // Variety control: recently studied concept is deprioritized
+  // concept_0 score: 10 - 3 = 7; concept_1 score: 8 → concept_1 wins
+  it("variety control: recently studied concept is deprioritized; next-ranked concept becomes primary", () => {
+    const result = buildDailyStudyPlanBundle(
+      makeInput({
+        totalAttempts: 30,
+        playerIntelligence: makeReadyIntelligence(),
+        recentlyStudiedConceptKeys: ["concept_0"],
+      }),
+    );
+    const focusBlock = result.plan45.blocks.find((b) => b.kind === "focus_concept");
+    expect(focusBlock?.conceptKey).toBe("concept_1");
+  });
+
+  // Variety + transfer recovery: recently studied AND high transfer pressure
+  // concept_0 score: 10 - 3 + 2 = 9; concept_1 score: 8 → concept_0 still wins
+  it("variety control: high transfer pressure on recently studied concept keeps it as primary", () => {
+    const result = buildDailyStudyPlanBundle(
+      makeInput({
+        totalAttempts: 30,
+        playerIntelligence: makeReadyIntelligence(),
+        recentlyStudiedConceptKeys: ["concept_0"],
+        transferEvaluationMap: makeTransferMap({ concept_0: "high" }),
+      }),
+    );
+    const focusBlock = result.plan45.blocks.find((b) => b.kind === "focus_concept");
+    // concept_0: 10 - 3 + 2 = 9 > concept_1: 8 → concept_0 is retained as primary
+    expect(focusBlock?.conceptKey).toBe("concept_0");
+  });
+
+  // Transfer pressure: high pressure enriches focus block reason
+  it("transfer pressure high: focus block reason mentions real-play confirmation gap", () => {
+    const result = buildDailyStudyPlanBundle(
+      makeInput({
+        totalAttempts: 30,
+        playerIntelligence: makeReadyIntelligence(),
+        transferEvaluationMap: makeTransferMap({ concept_0: "high" }),
+      }),
+    );
+    const focusBlock = result.plan45.blocks.find((b) => b.kind === "focus_concept");
+    expect(focusBlock?.reason).toContain("not yet confirmed in real play");
+  });
+
+  // Transfer pressure medium: no enrichment appended
+  it("transfer pressure medium: focus block reason is not enriched with transfer language", () => {
+    const result = buildDailyStudyPlanBundle(
+      makeInput({
+        totalAttempts: 30,
+        playerIntelligence: makeReadyIntelligence(),
+        transferEvaluationMap: makeTransferMap({ concept_0: "medium" }),
+      }),
+    );
+    const focusBlock = result.plan45.blocks.find((b) => b.kind === "focus_concept");
+    expect(focusBlock?.reason).not.toContain("not yet confirmed in real play");
+  });
+
+  // Calibration urgency: high-priority calibration enriches focus block reason
+  it("calibration high priority: focus block reason includes whyThisStillMatters text", () => {
+    const result = buildDailyStudyPlanBundle(
+      makeInput({
+        totalAttempts: 30,
+        playerIntelligence: makeReadyIntelligence(),
+        calibrationSurface: makeCalibrationSurface({ concept_0: "high" }),
+      }),
+    );
+    const focusBlock = result.plan45.blocks.find((b) => b.kind === "focus_concept");
+    expect(focusBlock?.reason).toContain("concept_0 calibration still matters");
+  });
+
+  // Calibration boost: high-priority calibration on recs[1] can overtake recs[0]
+  // concept_0 score: 10; concept_1 score: 8 + 2 = 10 → tied, stable sort keeps concept_0
+  // But if concept_0 recently studied: 10-3=7 vs concept_1: 8+2=10 → concept_1 wins
+  it("calibration boost combined with recency: high-calibration concept overtakes recently studied primary", () => {
+    const result = buildDailyStudyPlanBundle(
+      makeInput({
+        totalAttempts: 30,
+        playerIntelligence: makeReadyIntelligence(),
+        recentlyStudiedConceptKeys: ["concept_0"],
+        calibrationSurface: makeCalibrationSurface({ concept_1: "high" }),
+      }),
+    );
+    const focusBlock = result.plan45.blocks.find((b) => b.kind === "focus_concept");
+    // concept_0: 10 - 3 = 7; concept_1: 8 + 2 = 10 → concept_1 wins
+    expect(focusBlock?.conceptKey).toBe("concept_1");
+  });
+
+  // Secondary block also uses enriched reason when transfer is high
+  it("secondary block reason is enriched with transfer language when secondary concept has high pressure", () => {
+    const result = buildDailyStudyPlanBundle(
+      makeInput({
+        totalAttempts: 30,
+        playerIntelligence: makeReadyIntelligence(),
+        transferEvaluationMap: makeTransferMap({ concept_1: "high" }),
+      }),
+    );
+    const secondaryBlock = result.plan90.blocks.find((b) => b.kind === "secondary_concept");
+    expect(secondaryBlock?.conceptKey).toBe("concept_1");
+    expect(secondaryBlock?.reason).toContain("not yet confirmed in real play");
+  });
+
+  // No transfer data → reason is unchanged (no extra sentences appended)
+  it("no transfer or calibration data: reason is exactly the base rationale", () => {
+    const result = buildDailyStudyPlanBundle(
+      makeInput({ totalAttempts: 30, playerIntelligence: makeReadyIntelligence() }),
+    );
+    const focusBlock = result.plan45.blocks.find((b) => b.kind === "focus_concept");
+    expect(focusBlock?.reason).toContain("Concept 0");
+    expect(focusBlock?.reason).not.toContain("not yet confirmed");
+    expect(focusBlock?.reason).not.toContain("calibration still matters");
   });
 });

--- a/apps/table-sim/src/lib/daily-study-plan.ts
+++ b/apps/table-sim/src/lib/daily-study-plan.ts
@@ -1,6 +1,7 @@
-import type { PlayerIntelligenceSnapshot } from "@poker-coach/core/browser";
+import type { ConceptTransferEvaluation, PlayerIntelligenceSnapshot } from "@poker-coach/core/browser";
 import type { RealHandBridgeBundle } from "./real-hand-bridge";
 import { buildDailyPlanBridgeIntegration, findDailyPlanBridgeContext, type DailyPlanBridgeIntegration } from "./daily-plan-bridge-integration";
+import { findCalibrationSurfaceConcept, type CalibrationSurfaceAdapter } from "./calibration-surface";
 
 export type DailyPlanState = "ready" | "sparse_history" | "no_history";
 export type DailySessionLength = 20 | 45 | 90;
@@ -76,6 +77,12 @@ export interface DailyStudyPlanInput {
   now?: Date;
   /** v3: real-hand bridge bundle for enriching plan blocks and explanations */
   bridgeBundle?: RealHandBridgeBundle | null;
+  /** v5: per-concept transfer evaluation for boosting high-pressure concepts */
+  transferEvaluationMap?: Map<string, ConceptTransferEvaluation> | null;
+  /** v5: calibration surface for boosting high-priority regressing concepts */
+  calibrationSurface?: CalibrationSurfaceAdapter | null;
+  /** v5: recently studied concept keys — deprioritized for variety control */
+  recentlyStudiedConceptKeys?: string[];
 }
 
 function derivePlanState(input: DailyStudyPlanInput): DailyPlanState {
@@ -203,6 +210,75 @@ function buildFinishingCondition(blocks: DailyPlanBlock[], state: DailyPlanState
   return `When all ${blocks.length} blocks are marked done.`;
 }
 
+// ─── v5: assignment weight scoring ────────────────────────────────────────────
+
+/** Base scores for concept rank 0–4 in recommendations[]. 2-point gap between ranks. */
+const RANK_BASE_SCORES: readonly number[] = [10.0, 8.0, 6.0, 4.0, 2.0];
+
+/**
+ * Score a candidate recommendation for assignment selection.
+ * Higher score = stronger candidate for focus/secondary block.
+ *
+ * Boosts:  high transfer pressure +2.0, medium +0.5
+ *          high calibration priority +2.0, medium +0.5
+ * Penalty: recently studied concept -3.0
+ *
+ * The -3.0 penalty drops the top-ranked concept below the next rank (gap is 2pt),
+ * unless a +2.0 boost partially recovers it (net: penalised concept scores -1.0
+ * vs untouched next rank — next rank still wins by 1pt).
+ */
+function scoreConceptForAssignment(
+  conceptKey: string,
+  rankIndex: number,
+  transferEvaluationMap: Map<string, ConceptTransferEvaluation> | null | undefined,
+  calibrationSurface: CalibrationSurfaceAdapter | null | undefined,
+  recentlyStudiedConceptKeys: string[] | undefined,
+): number {
+  let score = RANK_BASE_SCORES[rankIndex] ?? 1.0;
+
+  // Transfer pressure boost: drill gains not yet confirming in real play
+  const transfer = transferEvaluationMap?.get(conceptKey);
+  if (transfer?.pressure === "high") score += 2.0;
+  else if (transfer?.pressure === "medium") score += 0.5;
+
+  // Calibration urgency boost: concept is regressing or inconclusive in calibration
+  const calibration = findCalibrationSurfaceConcept(calibrationSurface, conceptKey);
+  if (calibration?.priority === "high") score += 2.0;
+  else if (calibration?.priority === "medium") score += 0.5;
+
+  // Recency penalty: deprioritize concepts worked on recently for variety
+  if (recentlyStudiedConceptKeys?.includes(conceptKey)) score -= 3.0;
+
+  return score;
+}
+
+/**
+ * Enrich a block reason with transfer pressure and calibration urgency signals.
+ * Returns the base reason unchanged when no additional context is available.
+ */
+function enrichBlockReason(
+  baseReason: string,
+  conceptKey: string,
+  transferEvaluationMap: Map<string, ConceptTransferEvaluation> | null | undefined,
+  calibrationSurface: CalibrationSurfaceAdapter | null | undefined,
+): string {
+  const parts: string[] = [baseReason];
+
+  const transfer = transferEvaluationMap?.get(conceptKey);
+  if (transfer?.pressure === "high") {
+    parts.push(
+      "Drill gains on this concept are not yet confirmed in real play — sustained direct practice is the priority.",
+    );
+  }
+
+  const calibration = findCalibrationSurfaceConcept(calibrationSurface, conceptKey);
+  if (calibration?.priority === "high" && calibration.whyThisStillMatters) {
+    parts.push(calibration.whyThisStillMatters);
+  }
+
+  return parts.join(" ");
+}
+
 // ─── candidate block builders ─────────────────────────────────────────────────
 
 function buildCandidateBlocks(
@@ -294,6 +370,21 @@ function buildCandidateBlocks(
   const conceptMap = new Map(input.playerIntelligence.concepts.map((c) => [c.conceptKey, c]));
   const recommendations = input.playerIntelligence.recommendations;
 
+  // v5: score and re-rank recommendations using transfer pressure, calibration urgency,
+  // and recency penalty for variety control.
+  const scoredRecs = recommendations
+    .map((rec, index) => ({
+      rec,
+      score: scoreConceptForAssignment(
+        rec.conceptKey,
+        index,
+        input.transferEvaluationMap,
+        input.calibrationSurface,
+        input.recentlyStudiedConceptKeys,
+      ),
+    }))
+    .sort((a, b) => b.score - a.score);
+
   // Active intervention block (highest priority)
   // v3: enriched with real-hand evidence when bridge has a matching candidate
   if (input.activeInterventionConceptKey) {
@@ -341,15 +432,20 @@ function buildCandidateBlocks(
     });
   }
 
-  // Primary focus concept
-  const primaryRec = recommendations[0];
+  // Primary focus concept — v5: selected by assignment score, not raw rank
+  const primaryRec = scoredRecs[0]?.rec ?? null;
   if (primaryRec) {
     const basePriority = input.activeInterventionConceptKey ? 7 : 9;
     blocks.push({
       kind: "focus_concept",
       title: `Focus Concept: ${primaryRec.label}`,
       estimatedMinutes: 15,
-      reason: `${primaryRec.label} is your top-priority weakness. ${primaryRec.rationale}`,
+      reason: enrichBlockReason(
+        `${primaryRec.label} is your top-priority weakness. ${primaryRec.rationale}`,
+        primaryRec.conceptKey,
+        input.transferEvaluationMap,
+        input.calibrationSurface,
+      ),
       conceptKey: primaryRec.conceptKey,
       conceptLabel: primaryRec.label,
       destination: `/app/concepts/${encodeURIComponent(primaryRec.conceptKey)}`,
@@ -411,14 +507,19 @@ function buildCandidateBlocks(
     });
   }
 
-  // Secondary concept
-  const secondaryRec = recommendations[1];
+  // Secondary concept — v5: selected by assignment score, not raw rank
+  const secondaryRec = scoredRecs[1]?.rec ?? null;
   if (secondaryRec) {
     blocks.push({
       kind: "secondary_concept",
       title: `Secondary Concept: ${secondaryRec.label}`,
       estimatedMinutes: 10,
-      reason: `${secondaryRec.label} is your second-priority weakness. Adding breadth alongside depth work reinforces your overall game.`,
+      reason: enrichBlockReason(
+        `${secondaryRec.label} is your second-priority weakness. Adding breadth alongside depth work reinforces your overall game.`,
+        secondaryRec.conceptKey,
+        input.transferEvaluationMap,
+        input.calibrationSurface,
+      ),
       conceptKey: secondaryRec.conceptKey,
       conceptLabel: secondaryRec.label,
       destination: `/app/concepts/${encodeURIComponent(secondaryRec.conceptKey)}`,


### PR DESCRIPTION
## Summary

- **Assignment scoring**: `scoreConceptForAssignment()` replaces raw `recommendations[0/1]` selection with a weighted score — base rank scores `[10/8/6/4/2]`, +2 boost for high transfer pressure, +2 for high calibration priority, -3 recency penalty for variety control
- **Variety control**: `recentlyStudiedConceptKeys` optional input field; a -3 penalty bumps a recently-studied top recommendation below the next rank (7 vs 8), preventing repetitive daily assignment
- **Signal enrichment**: `enrichBlockReason()` appends a transfer-gap sentence when pressure is `"high"`, and the calibration `whyThisStillMatters` text when calibration priority is `"high"`
- **API route**: daily-study-plan route now computes and passes `transferEvaluationMap` (via `buildConceptTransferEvaluationMap`) and `calibrationSurface` (via `buildPersistedCalibrationOutcomesBundle` + `buildCalibrationSurfaceAdapter`)
- **9 new tests**: variety rotation, transfer pressure recovery, calibration boost, enriched reason text, secondary block enrichment, no-signal baseline

## Test plan

- [x] `pnpm test` — 339/339 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm build:web` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)